### PR TITLE
LIME-143: Call to DCS with user details

### DIFF
--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/domain/DcsPayload.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/domain/DcsPayload.java
@@ -56,8 +56,6 @@ public class DcsPayload {
             @JsonProperty(value = "surname", required = true) String surname,
             @JsonProperty(value = "forenames", required = true) List<String> forenames,
             @JsonProperty(value = "dateOfBirth", required = true) LocalDate dateOfBirth,
-            @JsonProperty(value = "issueDate", required = false) LocalDate issueDate,
-            @JsonProperty(value = "dateOfIssue", required = false) LocalDate dateOfIssue,
             @JsonProperty(value = "expiryDate", required = true) LocalDate expiryDate,
             @JsonProperty(value = "postcode", required = true) String postcode) {
         this.surname = surname;

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/gateway/ThirdPartyDocumentGateway.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/gateway/ThirdPartyDocumentGateway.java
@@ -118,14 +118,18 @@ public class ThirdPartyDocumentGateway {
         LocalDate drivingPermitExpiryDate = drivingPermitData.getExpiryDate();
         String drivingPermitDocumentNumber = drivingPermitData.getDrivingLicenceNumber();
 
+        String dcsEndpointUri = null;
         switch (licenceIssuer) {
             case DVA:
                 dcsPayload.setExpiryDate(drivingPermitExpiryDate);
 
                 dcsPayload.setDriverNumber(drivingPermitDocumentNumber);
                 dcsPayload.setDateOfIssue(drivingPermitData.getDateOfIssue());
+                dcsEndpointUri = configurationService.getDcsEndpointUri() + "/dva-driving-licence";
                 break;
             case DVLA:
+                dcsEndpointUri = configurationService.getDcsEndpointUri() + "/driving-licence";
+
                 dcsPayload.setExpiryDate(drivingPermitExpiryDate);
 
                 dcsPayload.setLicenceNumber(drivingPermitDocumentNumber);
@@ -144,7 +148,7 @@ public class ThirdPartyDocumentGateway {
 
         String requestBody = preparedDcsPayload.serialize();
         LOGGER.info("JOSE String " + requestBody);
-        URI endpoint = URI.create(configurationService.getDcsEndpointUri());
+        URI endpoint = URI.create(dcsEndpointUri);
         HttpPost request = requestBuilder(endpoint, requestBody);
 
         LOGGER.info("Submitting document check request to third party...");

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/gateway/ThirdPartyDocumentGatewayTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/gateway/ThirdPartyDocumentGatewayTest.java
@@ -131,7 +131,9 @@ class ThirdPartyDocumentGatewayTest {
         DocumentCheckResult actualDocumentCheckResult =
                 thirdPartyDocumentGateway.performDocumentCheck(drivingPermitForm);
 
-        assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
+        assertEquals(
+                TEST_ENDPOINT_URL + "/driving-licence",
+                httpRequestCaptor.getValue().getURI().toString());
         assertEquals("POST", httpRequestCaptor.getValue().getMethod());
 
         assertEquals(
@@ -168,7 +170,9 @@ class ThirdPartyDocumentGatewayTest {
         assertNotNull(actualFraudCheckResult);
         assertEquals(EXPECTED_ERROR, actualFraudCheckResult.getErrorMessage());
 
-        assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
+        assertEquals(
+                TEST_ENDPOINT_URL + "/driving-licence",
+                httpRequestCaptor.getValue().getURI().toString());
         assertEquals("POST", httpRequestCaptor.getValue().getMethod());
 
         assertEquals(
@@ -206,7 +210,9 @@ class ThirdPartyDocumentGatewayTest {
         assertNotNull(actualFraudCheckResult);
         assertEquals(EXPECTED_ERROR, actualFraudCheckResult.getErrorMessage());
 
-        assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
+        assertEquals(
+                TEST_ENDPOINT_URL + "/driving-licence",
+                httpRequestCaptor.getValue().getURI().toString());
         assertEquals("POST", httpRequestCaptor.getValue().getMethod());
 
         assertEquals(
@@ -245,7 +251,9 @@ class ThirdPartyDocumentGatewayTest {
         assertNotNull(actualFraudCheckResult);
         assertEquals(EXPECTED_ERROR, actualFraudCheckResult.getErrorMessage());
 
-        assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
+        assertEquals(
+                TEST_ENDPOINT_URL + "/driving-licence",
+                httpRequestCaptor.getValue().getURI().toString());
         assertEquals("POST", httpRequestCaptor.getValue().getMethod());
 
         assertEquals(
@@ -283,7 +291,9 @@ class ThirdPartyDocumentGatewayTest {
         assertNotNull(actualFraudCheckResult);
         assertEquals(EXPECTED_ERROR, actualFraudCheckResult.getErrorMessage());
 
-        assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
+        assertEquals(
+                TEST_ENDPOINT_URL + "/driving-licence",
+                httpRequestCaptor.getValue().getURI().toString());
         assertEquals("POST", httpRequestCaptor.getValue().getMethod());
 
         assertEquals(
@@ -320,7 +330,9 @@ class ThirdPartyDocumentGatewayTest {
                 thirdPartyDocumentGateway.performDocumentCheck(drivingPermitForm);
 
         assertNotNull(actualFraudCheckResult);
-        assertEquals(TEST_ENDPOINT_URL, httpRequestCaptor.getValue().getURI().toString());
+        assertEquals(
+                TEST_ENDPOINT_URL + "/driving-licence",
+                httpRequestCaptor.getValue().getURI().toString());
         assertEquals("POST", httpRequestCaptor.getValue().getMethod());
 
         assertEquals(

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/domain/DrivingPermitForm.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/domain/DrivingPermitForm.java
@@ -49,21 +49,17 @@ public class DrivingPermitForm {
             @JsonProperty(value = "surname", required = true) String surname,
             @JsonProperty(value = "forenames", required = true) List<String> forenames,
             @JsonProperty(value = "dateOfBirth", required = true) LocalDate dateOfBirth,
-            @JsonProperty(value = "issueDate", required = false) LocalDate issueDate,
             @JsonProperty(value = "expiryDate", required = true) LocalDate expiryDate,
             @JsonProperty(value = "licenceIssuer", required = true) String licenceIssuer,
             @JsonProperty(value = "drivingLicenceNumber", required = true)
                     String drivingLicenceNumber,
-            @JsonProperty(value = "issueNumber", required = false) String issueNumber,
             @JsonProperty(value = "postcode", required = true) String postcode) {
         this.surname = surname;
         this.forenames = forenames;
         this.dateOfBirth = dateOfBirth;
-        this.issueDate = issueDate;
         this.expiryDate = expiryDate;
         this.licenceIssuer = licenceIssuer;
         this.drivingLicenceNumber = drivingLicenceNumber;
-        this.issueNumber = issueNumber;
         this.postcode = postcode;
         List<Address> addresses = new ArrayList<>();
         Address address = new Address();


### PR DESCRIPTION
## Proposed changes

### What changed

Removed conditional fields from constructor
Updated endpoint config to not contain the path

### Why did it change

Fixed issues where some fields were being sent that were not required and the DVA service was not being queried

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-143](https://govukverify.atlassian.net/browse/LIME-143)

## Checklists

### Environment variables or secrets

Updated dcsEndpoint to remove path value
