### PR TITLE
LIME-197 Return 3 as GPG45 Strength and handle non-recoverable DCS er…

### DIFF
--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/gateway/ThirdPartyDocumentGateway.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/gateway/ThirdPartyDocumentGateway.java
@@ -193,15 +193,19 @@ public class ThirdPartyDocumentGateway {
         }
     }
 
-    private void validateDcsResponse(DcsResponse dcsResponse) {
+    private void validateDcsResponse(DcsResponse dcsResponse)
+            throws OAuthHttpResponseExceptionWithErrorBody {
         if (dcsResponse.isError()) {
             String errorMessage = dcsResponse.getErrorMessage().toString();
-            LOGGER.info("DCS encountered an error: {}", errorMessage);
+            LOGGER.error("DCS encountered an error: {}", errorMessage);
+            throw new OAuthHttpResponseExceptionWithErrorBody(
+                    HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.DCS_RETURNED_AN_ERROR);
         }
     }
 
     private DocumentCheckResult responseHandler(CloseableHttpResponse httpResponse)
-            throws IOException, ParseException, JOSEException, CertificateException {
+            throws IOException, ParseException, JOSEException, CertificateException,
+                    OAuthHttpResponseExceptionWithErrorBody {
         int statusCode = httpResponse.getStatusLine().getStatusCode();
         LOGGER.info("Third party response code {}", statusCode);
 

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
@@ -189,6 +189,10 @@ public class DrivingPermitHandler
             response.setRetry(canRetry);
 
             return ApiGatewayResponseGenerator.proxyJsonResponse(HttpStatusCode.OK, response);
+        } catch (OAuthHttpResponseExceptionWithErrorBody e) {
+            LOGGER.error("Encountered error in DCS request : {}", e.getErrorReason());
+            return ApiGatewayResponseGenerator.proxyJsonResponse(
+                    e.getStatusCode(), e.getErrorReason());
         } catch (Exception e) {
             LOGGER.warn("Exception while handling lambda {}", context.getFunctionName());
             eventProbe.log(Level.ERROR, e).counterMetric(LAMBDA_NAME, 0d);

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/IdentityVerificationService.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/IdentityVerificationService.java
@@ -22,7 +22,7 @@ public class IdentityVerificationService {
             "Null DrivingPermitCheckResult returned when invoking third party API.";
     private static final String ERROR_DRIVING_PERMIT_CHECK_RESULT_NO_ERR_MSG =
             "DrivingPermitCheckResult had no error message.";
-    private static final int MAX_DRIVING_PERMIT_GPG45_STRENGTH_VALUE = 4;
+    private static final int MAX_DRIVING_PERMIT_GPG45_STRENGTH_VALUE = 3;
     private static final int MAX_DRIVING_PERMIT_GPG45_VALIDITY_VALUE = 2;
     private static final int MIN_DRIVING_PERMIT_GPG45_VALUE = 0;
     private static final int MAX_DRIVING_ACTIVITY_HISTORY_SCORE = 1;
@@ -114,6 +114,9 @@ public class IdentityVerificationService {
             LOGGER.error(ERROR_DRIVING_PERMIT_CHECK_RESULT_RETURN_NULL);
             result.setError(ERROR_MSG_CONTEXT);
             result.setExecutedSuccessfully(false);
+        } catch (OAuthHttpResponseExceptionWithErrorBody e) {
+            // Specific exception for non-recoverable DCS related errors
+            throw e;
         } catch (InterruptedException ie) {
             LOGGER.error(ERROR_MSG_CONTEXT, ie);
             Thread.currentThread().interrupt();


### PR DESCRIPTION
## Proposed changes

### What changed

GPG45 Strength changed to the value 3

Stopped catching non-recoverable DCS related errors in IdentityVerificationService

### Why did it change

UK photocard driving licences have a score of 3

Errors either preparing the DCS request or receiving the DCS response are now treated as non-recoverable internal server errors with a logged error message as to why

### Issue tracking

- [LIME-197](https://govukverify.atlassian.net/browse/LIME-197)
