### PR TITLE
LIME 140 Improve Handling and logging of non-recoverable DCS related errors

### DIFF
--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/error/ErrorResponse.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/error/ErrorResponse.java
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ErrorResponse {
-    FAILED_TO_PARSE_DRIVING_PERMIT_FORM_DATA(1000, "Failed to parse passport form data"),
+    FAILED_TO_PARSE_DRIVING_PERMIT_FORM_DATA(1000, "Failed to parse Driving Permit form data"),
     MISSING_QUERY_PARAMETERS(1001, "Missing query parameters for auth request"),
     FAILED_TO_PARSE_OAUTH_QUERY_STRING_PARAMETERS(
             1002, "Failed to parse oauth2-specific query string parameters"),
     FAILED_TO_PREPARE_DCS_PAYLOAD(1003, "Failed to prepare DCS payload"),
-    ERROR_CONTACTING_DCS(1004, "Error when contacting DCS for passport check"),
+    ERROR_CONTACTING_DCS(1004, "Error when contacting DCS for document check"),
     FAILED_TO_UNWRAP_DCS_RESPONSE(1005, "Failed to unwrap Dcs response"),
     DCS_RETURNED_AN_ERROR(1006, "DCS returned an error response"),
     MISSING_SHARED_ATTRIBUTES_JWT(1007, "Missing shared attributes JWT from request body"),
@@ -22,9 +22,15 @@ public enum ErrorResponse {
     FAILED_TO_SEND_AUDIT_MESSAGE_TO_SQS_QUEUE(
             1016, "Failed to send message to aws SQS audit event queue"),
     MISSING_USER_ID_HEADER(1017, "Missing user_id header in authorisation request"),
-    MISSING_PASSPORT_SESSION_ID_HEADER(1018, "Missing passport_session_id header"),
+    MISSING_SESSION_ID_HEADER(1018, "Missing session_id header"),
     FAILED_TO_REVOKE_ACCESS_TOKEN(1019, "Failed to revoke access token"),
-    PASSPORT_SESSION_NOT_FOUND(1020, "Passport session not found");
+    SESSION_NOT_FOUND(1020, "Session not found"),
+
+    FORM_DATA_FAILED_VALIDATION(1021, "Form Data failed validation"),
+    DCS_ERROR_HTTP_30x(1022, "DCS Responded with a HTTP Redirection status code"),
+    DCS_ERROR_HTTP_40x(1023, "DCS Responded with a HTTP Client Error status code"),
+    DCS_ERROR_HTTP_50x(1024, "DCS Responded with a HTTP Server Error status code"),
+    DCS_ERROR_HTTP_X(1025, "DCS Responded with an unhandled HTTP status code");
 
     private final int code;
     private final String message;

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/FormDataValidator.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/FormDataValidator.java
@@ -12,7 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-class PersonIdentityValidator {
+class FormDataValidator {
 
     private static final Logger LOGGER = LogManager.getLogger();
     public static final int MIN_SUPPORTED_ADDRESSES = 1;
@@ -26,15 +26,14 @@ class PersonIdentityValidator {
     ValidationResult<List<String>> validate(DrivingPermitForm drivingPermitForm) {
         List<String> validationErrors = new ArrayList<>();
 
-        String givenames;
-        try {
-            givenames = String.join(" ", drivingPermitForm.getForenames());
-        } catch (NullPointerException e) {
-            givenames = null;
+        List<String> foreNames = drivingPermitForm.getForenames();
+        if (JsonValidationUtility.validateListDataEmptyIsFail(
+                foreNames, "Forenames", validationErrors)) {
+            for (String name : drivingPermitForm.getForenames()) {
+                JsonValidationUtility.validateStringDataEmptyIsFail(
+                        name, NAME_STRING_MAX_LEN, "Forename", validationErrors);
+            }
         }
-
-        JsonValidationUtility.validateStringDataEmptyIsFail(
-                givenames, NAME_STRING_MAX_LEN, "FirstName", validationErrors);
 
         JsonValidationUtility.validateStringDataEmptyIsFail(
                 drivingPermitForm.getSurname(), NAME_STRING_MAX_LEN, "Surname", validationErrors);

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ServiceFactory.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ServiceFactory.java
@@ -33,7 +33,7 @@ public class ServiceFactory {
     private final ContraindicationMapper contraindicationMapper;
     private final DcsCryptographyService dcsCryptographyService;
     private final ConfigurationService configurationService;
-    private final PersonIdentityValidator personIdentityValidator;
+    private final FormDataValidator formDataValidator;
     private final ObjectMapper objectMapper;
     private final CloseableHttpClient httpClient;
     private final AuditService auditService;
@@ -43,7 +43,7 @@ public class ServiceFactory {
             throws NoSuchAlgorithmException, InvalidKeyException, CertificateException,
                     InvalidKeySpecException, KeyStoreException, IOException, HttpException {
         this.objectMapper = objectMapper;
-        this.personIdentityValidator = new PersonIdentityValidator();
+        this.formDataValidator = new FormDataValidator();
         this.configurationService = createConfigurationService();
         this.dcsCryptographyService = new DcsCryptographyService(configurationService);
         this.contraindicationMapper = new ContraIndicatorRemoteMapper(configurationService);
@@ -59,7 +59,7 @@ public class ServiceFactory {
             ConfigurationService configurationService,
             DcsCryptographyService dcsCryptographyService,
             ContraindicationMapper contraindicationMapper,
-            PersonIdentityValidator personIdentityValidator,
+            FormDataValidator formDataValidator,
             CloseableHttpClient httpClient,
             AuditService auditService,
             HttpRetryer httpRetryer)
@@ -68,7 +68,7 @@ public class ServiceFactory {
         this.configurationService = configurationService;
         this.dcsCryptographyService = dcsCryptographyService;
         this.contraindicationMapper = contraindicationMapper;
-        this.personIdentityValidator = personIdentityValidator;
+        this.formDataValidator = formDataValidator;
         this.httpClient = httpClient;
         this.auditService = auditService;
         this.httpRetryer = httpRetryer;
@@ -103,7 +103,7 @@ public class ServiceFactory {
 
         return new IdentityVerificationService(
                 thirdPartyGateway,
-                this.personIdentityValidator,
+                this.formDataValidator,
                 this.contraindicationMapper,
                 auditService,
                 configurationService,

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/gateway/ThirdPartyDocumentGatewayTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/gateway/ThirdPartyDocumentGatewayTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DcsPayload;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DcsResponse;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DocumentCheckResult;
+import uk.gov.di.ipv.cri.drivingpermit.api.error.ErrorResponse;
 import uk.gov.di.ipv.cri.drivingpermit.api.exception.OAuthHttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.ConfigurationService;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.DcsCryptographyService;
@@ -162,13 +163,17 @@ class ThirdPartyDocumentGatewayTest {
         when(this.httpRetryer.sendHTTPRequestRetryIfAllowed(httpRequestCaptor.capture()))
                 .thenReturn(httpResponse);
 
-        DocumentCheckResult actualFraudCheckResult =
-                thirdPartyDocumentGateway.performDocumentCheck(drivingPermitForm);
+        OAuthHttpResponseExceptionWithErrorBody e =
+                assertThrows(
+                        OAuthHttpResponseExceptionWithErrorBody.class,
+                        () -> {
+                            DocumentCheckResult actualFraudCheckResult =
+                                    thirdPartyDocumentGateway.performDocumentCheck(
+                                            drivingPermitForm);
+                        });
 
-        final String EXPECTED_ERROR = ThirdPartyDocumentGateway.HTTP_300_REDIRECT_MESSAGE + 300;
-
-        assertNotNull(actualFraudCheckResult);
-        assertEquals(EXPECTED_ERROR, actualFraudCheckResult.getErrorMessage());
+        final String EXPECTED_ERROR = ErrorResponse.DCS_ERROR_HTTP_30x.getMessage();
+        assertEquals(EXPECTED_ERROR, e.getErrorResponse().getMessage());
 
         assertEquals(
                 TEST_ENDPOINT_URL + "/driving-licence",
@@ -202,13 +207,17 @@ class ThirdPartyDocumentGatewayTest {
         when(this.httpRetryer.sendHTTPRequestRetryIfAllowed(httpRequestCaptor.capture()))
                 .thenReturn(httpResponse);
 
-        DocumentCheckResult actualFraudCheckResult =
-                thirdPartyDocumentGateway.performDocumentCheck(drivingPermitForm);
+        OAuthHttpResponseExceptionWithErrorBody e =
+                assertThrows(
+                        OAuthHttpResponseExceptionWithErrorBody.class,
+                        () -> {
+                            DocumentCheckResult actualFraudCheckResult =
+                                    thirdPartyDocumentGateway.performDocumentCheck(
+                                            drivingPermitForm);
+                        });
 
-        final String EXPECTED_ERROR = ThirdPartyDocumentGateway.HTTP_400_CLIENT_REQUEST_ERROR + 400;
-
-        assertNotNull(actualFraudCheckResult);
-        assertEquals(EXPECTED_ERROR, actualFraudCheckResult.getErrorMessage());
+        final String EXPECTED_ERROR = ErrorResponse.DCS_ERROR_HTTP_40x.getMessage();
+        assertEquals(EXPECTED_ERROR, e.getErrorResponse().getMessage());
 
         assertEquals(
                 TEST_ENDPOINT_URL + "/driving-licence",
@@ -243,13 +252,17 @@ class ThirdPartyDocumentGatewayTest {
         when(this.httpRetryer.sendHTTPRequestRetryIfAllowed(httpRequestCaptor.capture()))
                 .thenReturn(httpResponse);
 
-        DocumentCheckResult actualFraudCheckResult =
-                thirdPartyDocumentGateway.performDocumentCheck(drivingPermitForm);
+        OAuthHttpResponseExceptionWithErrorBody e =
+                assertThrows(
+                        OAuthHttpResponseExceptionWithErrorBody.class,
+                        () -> {
+                            DocumentCheckResult actualFraudCheckResult =
+                                    thirdPartyDocumentGateway.performDocumentCheck(
+                                            drivingPermitForm);
+                        });
 
-        final String EXPECTED_ERROR = ThirdPartyDocumentGateway.HTTP_500_SERVER_ERROR + 500;
-
-        assertNotNull(actualFraudCheckResult);
-        assertEquals(EXPECTED_ERROR, actualFraudCheckResult.getErrorMessage());
+        final String EXPECTED_ERROR = ErrorResponse.DCS_ERROR_HTTP_50x.getMessage();
+        assertEquals(EXPECTED_ERROR, e.getErrorResponse().getMessage());
 
         assertEquals(
                 TEST_ENDPOINT_URL + "/driving-licence",
@@ -282,14 +295,17 @@ class ThirdPartyDocumentGatewayTest {
         when(this.httpRetryer.sendHTTPRequestRetryIfAllowed(httpRequestCaptor.capture()))
                 .thenReturn(httpResponse);
 
-        DocumentCheckResult actualFraudCheckResult =
-                thirdPartyDocumentGateway.performDocumentCheck(drivingPermitForm);
+        OAuthHttpResponseExceptionWithErrorBody e =
+                assertThrows(
+                        OAuthHttpResponseExceptionWithErrorBody.class,
+                        () -> {
+                            DocumentCheckResult actualFraudCheckResult =
+                                    thirdPartyDocumentGateway.performDocumentCheck(
+                                            drivingPermitForm);
+                        });
 
-        final String EXPECTED_ERROR =
-                ThirdPartyDocumentGateway.HTTP_UNHANDLED_ERROR + MOCK_HTTP_STATUS_CODE;
-
-        assertNotNull(actualFraudCheckResult);
-        assertEquals(EXPECTED_ERROR, actualFraudCheckResult.getErrorMessage());
+        final String EXPECTED_ERROR = ErrorResponse.DCS_ERROR_HTTP_X.getMessage();
+        assertEquals(EXPECTED_ERROR, e.getErrorResponse().getMessage());
 
         assertEquals(
                 TEST_ENDPOINT_URL + "/driving-licence",

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/FormDataValidatorTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/FormDataValidatorTest.java
@@ -17,26 +17,26 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class PersonIdentityValidatorTest {
+class FormDataValidatorTest {
 
     private static final Logger LOGGER = LogManager.getLogger();
 
     @Test
-    void testPersonIdentityNameCannotBeNull() {
+    void testFormDataValidatorNamesCannotBeNull() {
 
         final String TEST_STRING = null;
 
         DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
         drivingPermitForm.setForenames(null);
         drivingPermitForm.setSurname(TEST_STRING);
 
         ValidationResult<List<String>> validationResult =
-                personIdentityValidator.validate(drivingPermitForm);
+                formDataValidator.validate(drivingPermitForm);
 
         final String EXPECTED_ERROR_0 =
-                "FirstName" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
+                "Forenames" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
         final String EXPECTED_ERROR_1 =
                 "Surname" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
 
@@ -51,17 +51,17 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityDOBCannotBeNull() {
+    void testFormDataValidatorDOBCannotBeNull() {
 
         final LocalDate TEST_LOCAL_DATE = null;
 
         DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
         drivingPermitForm.setDateOfBirth(TEST_LOCAL_DATE);
 
         ValidationResult<List<String>> validationResult =
-                personIdentityValidator.validate(drivingPermitForm);
+                formDataValidator.validate(drivingPermitForm);
 
         final String EXPECTED_ERROR =
                 "DateOfBirth" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
@@ -75,17 +75,17 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityAddressesCannotBeNull() {
+    void testFormDataValidatorAddressesCannotBeNull() {
 
         final List<Address> TEST_ADDRESSES = null;
 
         DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
         drivingPermitForm.setAddresses(TEST_ADDRESSES);
 
         ValidationResult<List<String>> validationResult =
-                personIdentityValidator.validate(drivingPermitForm);
+                formDataValidator.validate(drivingPermitForm);
 
         final String EXPECTED_ERROR =
                 "Addresses" + JsonValidationUtility.IS_NULL_ERROR_MESSAGE_SUFFIX;
@@ -99,17 +99,17 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityAddressesCannotBeEmpty() {
+    void testFormDataValidatorAddressesCannotBeEmpty() {
 
         final List<Address> TEST_ADDRESSES = new ArrayList<>();
 
         DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
         drivingPermitForm.setAddresses(TEST_ADDRESSES);
 
         ValidationResult<List<String>> validationResult =
-                personIdentityValidator.validate(drivingPermitForm);
+                formDataValidator.validate(drivingPermitForm);
 
         final String TEST_INTEGER_NAME = "Addresses";
         final int TEST_VALUE = TEST_ADDRESSES.size();
@@ -117,8 +117,8 @@ class PersonIdentityValidatorTest {
         final String EXPECTED_ERROR =
                 JsonValidationUtility.createIntegerRangeErrorMessage(
                         TEST_VALUE,
-                        PersonIdentityValidator.MIN_SUPPORTED_ADDRESSES,
-                        PersonIdentityValidator.MAX_SUPPORTED_ADDRESSES,
+                        FormDataValidator.MIN_SUPPORTED_ADDRESSES,
+                        FormDataValidator.MAX_SUPPORTED_ADDRESSES,
                         TEST_INTEGER_NAME);
 
         LOGGER.info(validationResult.getError().toString());
@@ -130,9 +130,9 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityTooManyAddressesFail() {
+    void testFormDataValidatorTooManyAddressesFail() {
 
-        final int addressChainLength = PersonIdentityValidator.MAX_SUPPORTED_ADDRESSES;
+        final int addressChainLength = FormDataValidator.MAX_SUPPORTED_ADDRESSES;
         final int additionalCurrentAddresses = 1;
         final int additionalPreviousAddresses = 0;
         final int TOTAL_ADDRESSES = addressChainLength + additionalCurrentAddresses;
@@ -145,16 +145,16 @@ class PersonIdentityValidatorTest {
                         additionalPreviousAddresses,
                         shuffleAddresses);
 
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
         ValidationResult<List<String>> validationResult =
-                personIdentityValidator.validate(drivingPermitForm);
+                formDataValidator.validate(drivingPermitForm);
 
         final String EXPECTED_ERROR =
                 JsonValidationUtility.createIntegerRangeErrorMessage(
                         TOTAL_ADDRESSES,
-                        PersonIdentityValidator.MIN_SUPPORTED_ADDRESSES,
-                        PersonIdentityValidator.MAX_SUPPORTED_ADDRESSES,
+                        FormDataValidator.MIN_SUPPORTED_ADDRESSES,
+                        FormDataValidator.MAX_SUPPORTED_ADDRESSES,
                         "Addresses");
 
         LOGGER.info(validationResult.getError().toString());
@@ -166,7 +166,7 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityAddressesValidCurrentAddressIsOk() {
+    void testFormDataValidatorAddressesValidCurrentAddressIsOk() {
 
         final Address TEST_CURRENT_ADDRESS = new Address();
         TEST_CURRENT_ADDRESS.setValidFrom(LocalDate.now());
@@ -174,12 +174,12 @@ class PersonIdentityValidatorTest {
         final List<Address> TEST_ADDRESSES = List.of(TEST_CURRENT_ADDRESS);
 
         DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
         drivingPermitForm.setAddresses(TEST_ADDRESSES);
 
         ValidationResult<List<String>> validationResult =
-                personIdentityValidator.validate(drivingPermitForm);
+                formDataValidator.validate(drivingPermitForm);
 
         assertEquals(TEST_ADDRESSES, drivingPermitForm.getAddresses());
         assertEquals(0, validationResult.getError().size());
@@ -187,7 +187,7 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityAddressesCurrentAddressNullDatesIsOk() {
+    void testFormDataValidatorAddressesCurrentAddressNullDatesIsOk() {
         // Edge case scenario : A current address where user does not know when exactly they moved
         // in (ValidFrom null).
 
@@ -198,12 +198,12 @@ class PersonIdentityValidatorTest {
         final List<Address> TEST_ADDRESSES = List.of(TEST_CURRENT_ADDRESS);
 
         DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
         drivingPermitForm.setAddresses(TEST_ADDRESSES);
 
         ValidationResult<List<String>> validationResult =
-                personIdentityValidator.validate(drivingPermitForm);
+                formDataValidator.validate(drivingPermitForm);
 
         assertEquals(TEST_ADDRESSES, drivingPermitForm.getAddresses());
         assertEquals(0, validationResult.getError().size());
@@ -211,7 +211,7 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityAddressesCurrentAddressWithFutureDatesIsFail() {
+    void testFormDataValidatorAddressesCurrentAddressWithFutureDatesIsFail() {
 
         final Address TEST_CURRENT_ADDRESS = new Address();
         TEST_CURRENT_ADDRESS.setValidFrom(LocalDate.now().plusYears(1));
@@ -220,15 +220,14 @@ class PersonIdentityValidatorTest {
         final List<Address> TEST_ADDRESSES = List.of(TEST_CURRENT_ADDRESS);
 
         DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
         drivingPermitForm.setAddresses(TEST_ADDRESSES);
 
         ValidationResult<List<String>> validationResult =
-                personIdentityValidator.validate(drivingPermitForm);
+                formDataValidator.validate(drivingPermitForm);
 
-        final String EXPECTED_ERROR =
-                PersonIdentityValidator.createAddressCheckErrorMessage(1, 0, 0, 1);
+        final String EXPECTED_ERROR = FormDataValidator.createAddressCheckErrorMessage(1, 0, 0, 1);
 
         LOGGER.info(validationResult.getError().toString());
 
@@ -239,7 +238,7 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityAddressesValidCurrentAndPreviousAddressIsOk() {
+    void testFormDataValidatorAddressesValidCurrentAndPreviousAddressIsOk() {
 
         final Address TEST_CURRENT_ADDRESS = new Address();
         TEST_CURRENT_ADDRESS.setValidFrom(LocalDate.of(1999, 12, 31));
@@ -252,12 +251,12 @@ class PersonIdentityValidatorTest {
         final List<Address> TEST_ADDRESSES = List.of(TEST_CURRENT_ADDRESS, TEST_PREVIOUS_ADDRESS);
 
         DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
         drivingPermitForm.setAddresses(TEST_ADDRESSES);
 
         ValidationResult<List<String>> validationResult =
-                personIdentityValidator.validate(drivingPermitForm);
+                formDataValidator.validate(drivingPermitForm);
 
         LOGGER.info(validationResult.getError().toString());
 
@@ -267,7 +266,7 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityAddressesAValidCurrentAndPreviousAddressAreInReverseOrderIsOk() {
+    void testFormDataValidatorAddressesAValidCurrentAndPreviousAddressAreInReverseOrderIsOk() {
 
         final Address TEST_CURRENT_ADDRESS = new Address();
         TEST_CURRENT_ADDRESS.setValidFrom(LocalDate.now());
@@ -278,12 +277,12 @@ class PersonIdentityValidatorTest {
         final List<Address> TEST_ADDRESSES = List.of(TEST_PREVIOUS_ADDRESS, TEST_CURRENT_ADDRESS);
 
         DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
         drivingPermitForm.setAddresses(TEST_ADDRESSES);
 
         ValidationResult<List<String>> validationResult =
-                personIdentityValidator.validate(drivingPermitForm);
+                formDataValidator.validate(drivingPermitForm);
 
         assertEquals(TEST_ADDRESSES, drivingPermitForm.getAddresses());
         assertEquals(0, validationResult.getError().size());
@@ -291,7 +290,7 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityAddressesValidCurrentAndPreviousAddressOverlapIsOk() {
+    void testFormDataValidatorAddressesValidCurrentAndPreviousAddressOverlapIsOk() {
         // Edge case scenario : A current address where user has moved out of the previous on the
         // current date
         // (CURRENT ValidFrom == PREVIOUS ValidUntil).
@@ -305,12 +304,12 @@ class PersonIdentityValidatorTest {
         final List<Address> TEST_ADDRESSES = List.of(TEST_CURRENT_ADDRESS, TEST_PREVIOUS_ADDRESS);
 
         DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
         drivingPermitForm.setAddresses(TEST_ADDRESSES);
 
         ValidationResult<List<String>> validationResult =
-                personIdentityValidator.validate(drivingPermitForm);
+                formDataValidator.validate(drivingPermitForm);
 
         assertEquals(TEST_ADDRESSES, drivingPermitForm.getAddresses());
         assertEquals(0, validationResult.getError().size());
@@ -318,7 +317,7 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityAddressesMultipleCurrentAddressesIsOk() {
+    void testFormDataValidatorAddressesMultipleCurrentAddressesIsOk() {
 
         final Address TEST_CURRENT_ADDRESS_1 = new Address();
         TEST_CURRENT_ADDRESS_1.setValidFrom(LocalDate.now());
@@ -332,12 +331,12 @@ class PersonIdentityValidatorTest {
                 List.of(TEST_CURRENT_ADDRESS_1, TEST_CURRENT_ADDRESS_2);
 
         DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
         drivingPermitForm.setAddresses(TEST_ADDRESSES);
 
         ValidationResult<List<String>> validationResult =
-                personIdentityValidator.validate(drivingPermitForm);
+                formDataValidator.validate(drivingPermitForm);
 
         assertEquals(TEST_ADDRESSES, drivingPermitForm.getAddresses());
         assertEquals(0, validationResult.getError().size());
@@ -345,7 +344,7 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityAddressesManyPreviousAddressesFail() {
+    void testFormDataValidatorAddressesManyPreviousAddressesFail() {
 
         final int addressChainLength = 0;
         final int additionalCurrentAddresses = 0;
@@ -361,12 +360,12 @@ class PersonIdentityValidatorTest {
                         additionalPreviousAddresses,
                         shuffleAddresses);
 
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
-        ValidationResult<List<String>> validationResult = personIdentityValidator.validate(form);
+        ValidationResult<List<String>> validationResult = formDataValidator.validate(form);
 
         final String EXPECTED_ERROR =
-                PersonIdentityValidator.createAddressCheckErrorMessage(
+                FormDataValidator.createAddressCheckErrorMessage(
                         TOTAL_ADDRESSES,
                         additionalCurrentAddresses,
                         additionalPreviousAddresses,
@@ -381,7 +380,7 @@ class PersonIdentityValidatorTest {
     }
 
     @Test
-    void testPersonIdentityAddressesManyValidCurrentAndValidPreviousAddressesOutOfOrderIsOK() {
+    void testFormDataValidatorAddressesManyValidCurrentAndValidPreviousAddressesOutOfOrderIsOK() {
 
         final int addressChainLength = 10;
         final int additionalCurrentAddresses = 5;
@@ -397,9 +396,9 @@ class PersonIdentityValidatorTest {
                         additionalPreviousAddresses,
                         shuffleAddresses);
 
-        PersonIdentityValidator personIdentityValidator = new PersonIdentityValidator();
+        FormDataValidator formDataValidator = new FormDataValidator();
 
-        ValidationResult<List<String>> validationResult = personIdentityValidator.validate(form);
+        ValidationResult<List<String>> validationResult = formDataValidator.validate(form);
 
         assertEquals(TOTAL_ADDRESSES, form.getAddresses().size());
         assertEquals(0, validationResult.getError().size());

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ServiceFactoryTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ServiceFactoryTest.java
@@ -19,7 +19,7 @@ class ServiceFactoryTest {
     @Mock private ObjectMapper mockObjectMapper;
     @Mock private ConfigurationService mockConfigurationService;
     @Mock private ContraindicationMapper mockContraindicationMapper;
-    @Mock private PersonIdentityValidator mockPersonIdentityValidator;
+    @Mock private FormDataValidator mockFormDataValidator;
     @Mock private CloseableHttpClient mockHttpClient;
     @Mock private DcsCryptographyService mockDcsCryptographyService;
     @Mock private HttpRetryer mockHttpRetryer;
@@ -35,7 +35,7 @@ class ServiceFactoryTest {
                         mockConfigurationService,
                         mockDcsCryptographyService,
                         mockContraindicationMapper,
-                        mockPersonIdentityValidator,
+                        mockFormDataValidator,
                         mockHttpClient,
                         mockAuditService,
                         mockHttpRetryer);


### PR DESCRIPTION
## Proposed changes

### What changed

Treat as as non recoverable errors

- HTTP 400, seen when a client side encryption cert has expired
- All HTTP Status codes other than 200 and 429 (unless last connection retry)
- IpvCryptoException, seen when client signing verification cert expired, and all signature verification fails.
- FormDataValidator validation failing

### Why did it change

Previously a user retry would be attempted in these scenarios with a CRI NP thrown when attempting to save attempts that never completed

FormDataValidator is renamed from PersonIdentityValidator to better fit its use (repurposed from fraudCRI)
- Main validation is on the front end, FormDataValidator is doing field presence checks
- Logging message changed to Validating form data...(Start), Form data validated. (Passed)
- If Form Data Validation fails, treated as non recoverable and logged as Form Data failed validation + list of missing fields

### Issue tracking

- [LIME-140](https://govukverify.atlassian.net/browse/LIME-140)
