### PR TITLE
OJ-999 - Transition to common CRI framework

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -54,7 +54,7 @@ jobs:
           sam deploy \
             --no-fail-on-empty-changeset \
             --no-confirm-changeset \
-            --parameter-overrides Environment=${{ env.ENVIRONMENT }} \
+            --parameter-overrides "Environment=${{ env.ENVIRONMENT }} CodeSigningEnabled=false AuditEventNamePrefix=/common-cri-parameters/DrivingPermitAuditEventNamePrefix CriIdentifier=/common-cri-parameters/DrivingPermitCriIdentifier CommonStackName=driving-permit-common-cri-api" \
             --stack-name $STACK_NAME \
             --s3-bucket ${{ secrets.AWS_CONFIG_BUCKET }} \
             --s3-prefix $STACK_NAME \

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "common-lambdas"]
-	path = common-lambdas
-	url = git@github.com:alphagov/di-ipv-cri-common-lambdas
 [submodule "acceptance-tests"]
 	path = acceptance-tests
 	url = git@github.com:alphagov/di-ipv-cri-fraud-test.git

--- a/README.md
+++ b/README.md
@@ -34,25 +34,15 @@ See onboarding guide for instructions on how to setup the following command line
 
 ### Deploy to dev account
 
-Before your **first** deploy, build a sam config toml file.
-> The stack name *must* be unique to you.
-> Ensure you set **Parameter Environment** and **SAM configuration environment**, when asked to `dev`.
-> All other defaults can be accepted by leaving them blank
-
-The command to run is: 
-
-`gds aws  di-ipv-cri-dev -- sam deploy -t infrastructure/lambda/template.yaml --guided`
-
 Any time you wish to deploy, run:
 
 `gds aws di-ipv-cri-dev -- ./deploy.sh my-stack-name`
 
 ### Delete stack from dev account
 > The stack name *must* be unique to you and created by you in the deploy stage above.
-> The default location of sam config toml file is `./infrastructure/lambda/samconfig.toml`.
 > **Remember to specify the environment name**:`dev`.
 > Type `y`es when prompted to delete the stack and the folders in S3 bucket
 
 The command to run is:
 
-`gds aws di-ipv-cri-dev -- sam delete --config-file ./infrastructure/lambda/samconfig.toml --config-env dev --stack-name <unique-stack-name>`
+`gds aws di-ipv-cri-dev -- sam delete --config-env dev --stack-name <unique-stack-name>`

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ echo -e "Stack name expected as first argument, e.g. ./deploy.sh my-driving-perm
 exit 1
 fi
 
-./gradlew
+./gradlew clean
 
 sam validate -t infrastructure/lambda/template.yaml --config-env dev
 
@@ -21,4 +21,4 @@ sam deploy --stack-name $stack_name \
    --resolve-s3 \
    --region eu-west-2 \
    --capabilities CAPABILITY_IAM \
-   --parameter-overrides Environment=dev
+   --parameter-overrides CodeSigningEnabled=false Environment=dev AuditEventNamePrefix=/common-cri-parameters/DrivingPermitAuditEventNamePrefix CriIdentifier=/common-cri-parameters/DrivingPermitCriIdentifier CommonStackName=driving-permit-common-cri-api-local

--- a/infrastructure/lambda/private-api.yaml
+++ b/infrastructure/lambda/private-api.yaml
@@ -80,7 +80,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${SessionFunction.Arn}/invocations
+          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-SessionFunction/invocations
         responses:
           default:
             statusCode: "200"
@@ -121,7 +121,7 @@ paths:
         type: "aws_proxy"
         httpMethod: "POST"
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AuthorizationFunction.Arn}/invocations"
+          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AuthorizationFunction/invocations
         passthroughBehavior: "when_no_match"
 
 components:

--- a/infrastructure/lambda/public-api.yaml
+++ b/infrastructure/lambda/public-api.yaml
@@ -61,7 +61,7 @@ paths:
       x-amazon-apigateway-integration:
         httpMethod: "POST"
         uri:
-          Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AccessTokenFunction.Arn}/invocations
+          Fn::Sub: arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${CommonStackName}-AccessTokenFunction/invocations
         responses:
           default:
             statusCode: "200"

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -3,6 +3,9 @@ Transform: "AWS::Serverless-2016-10-31"
 Description: "Digital Identity Driving Permit Credential Issuer API"
 
 Parameters:
+  CodeSigningEnabled:
+    Type: "String"
+    Default: "true"
   CodeSigningConfigArn:
     Type: String
     Default: "none"
@@ -22,8 +25,23 @@ Parameters:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String
     Default: "none"
+  AuditEventNamePrefix:
+    Description: "The audit event name prefix"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/common-cri-parameters/AuditEventNamePrefix"
+  CriIdentifier:
+    Description: "The unique credential issuer identifier"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/common-cri-parameters/CriIdentifier"
+  CommonStackName:
+    Description: "The name of the stack containing the common CRI lambdas/infra"
+    Type: String
+    Default: "common-cri-api"
 
 Conditions:
+  EnforceCodeSigning: !Equals
+    - !Ref CodeSigningEnabled
+    - true
   CreateDevResources: !Equals
     - !Ref Environment
     - dev
@@ -61,9 +79,9 @@ Globals:
       - !Ref PermissionsBoundary
       - !Ref AWS::NoValue
     CodeSigningConfigArn: !If
-      - CreateDevResources
-      - !Ref AWS::NoValue
+      - EnforceCodeSigning
       - !Ref CodeSigningConfigArn
+      - !Ref AWS::NoValue
     Timeout: 30 # seconds
     Runtime: java11
     AutoPublishAlias: live
@@ -76,14 +94,17 @@ Globals:
         JAVA_TOOL_OPTIONS: -XX:+TieredCompilation -XX:TieredStopAtLevel=1
         AWS_STACK_NAME: !Sub ${AWS::StackName}
         POWERTOOLS_LOG_LEVEL: INFO
-        SQS_AUDIT_EVENT_PREFIX: IPV_DRIVING_PERMIT_CRI
-#    ProvisionedConcurrencyConfig: !If
-#      - IsProdEnvironment
-#      - ProvisionedConcurrentExecutions: 1
-#      - !Ref AWS::NoValue
+        SQS_AUDIT_EVENT_PREFIX: !Ref AuditEventNamePrefix
+        SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+        POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
+        COMMON_PARAMETER_NAME_PREFIX: !Ref CommonStackName
+        ENVIRONMENT: !Ref Environment
+    ProvisionedConcurrencyConfig: !If
+      - IsProdEnvironment
+      - ProvisionedConcurrentExecutions: 1
+      - !Ref AWS::NoValue
 
 Mappings:
-
   MemorySizeMapping:
     Environment:
       dev: 512
@@ -92,14 +113,6 @@ Mappings:
       integration: 1024
       production: 2048
 
-  SessionTtlMapping:
-    Environment:
-      dev: "172800" # 2 days
-      build: "172800" # 2 days
-      staging: "172800" # 2 days
-      integration: "172800" # 2 days
-      production: "172800" # 2 days
-
   MaxJwtTtlMapping:
     Environment:
       dev: "7200" # 2 hrs
@@ -107,79 +120,6 @@ Mappings:
       staging: "7200"
       integration: "7200"
       production: "7200"
-
-  IPVCoreStubAuthenticationAlgMapping:
-    Environment:
-      dev: "ES256"
-      build: "ES256"
-      staging: "ES256"
-      integration: "ES256"
-
-  IPVCore1AuthenticationAlgMapping:
-    Environment:
-      staging: "ES256"
-      integration: "ES256"
-      production: "ES256"
-
-  IPVCoreStubAudienceMapping:
-    Environment:
-      dev: "https://review-d.dev.account.gov.uk"
-      build: "https://review-d.build.account.gov.uk"
-      staging: "https://review-d.staging.account.gov.uk"
-      integration: "https://review-d.integration.account.gov.uk"
-
-  IPVCore1AudienceMapping:
-    Environment:
-      staging: "https://review-d.staging.account.gov.uk"
-      integration: "https://review-d.integration.account.gov.uk"
-      production: "https://review-d.account.gov.uk"
-
-  IPVCoreStubIssuerMapping:
-    Environment:
-      dev: "https://di-ipv-core-stub.london.cloudapps.digital"
-      build: "https://di-ipv-core-stub.london.cloudapps.digital"
-      staging: "https://di-ipv-core-stub.london.cloudapps.digital"
-      integration: "https://di-ipv-core-stub.london.cloudapps.digital"
-
-  IPVCore1IssuerMapping:
-    Environment:
-      staging: "https://identity.staging.account.gov.uk"
-      integration: "https://identity.integration.account.gov.uk"
-      production: "https://identity.account.gov.uk"
-
-  IPVCoreStubPublicSigningJwkBase64Mapping:
-    Environment:
-      dev: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0yLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogImszOXVLYWNTdWtRQnJNWnJIRFRCVVpzbGl2cFhLRE5aVGc2aW5DSHdyTGMiLAogICAgInkiOiAiOEY4TG5RN3dHOWh4c1Q0YXgwQXR5N2lNR0l5aVlfWUdwM19xSVp6S28xQSIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
-      build: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0yLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogImszOXVLYWNTdWtRQnJNWnJIRFRCVVpzbGl2cFhLRE5aVGc2aW5DSHdyTGMiLAogICAgInkiOiAiOEY4TG5RN3dHOWh4c1Q0YXgwQXR5N2lNR0l5aVlfWUdwM19xSVp6S28xQSIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
-      staging: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0yLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogImszOXVLYWNTdWtRQnJNWnJIRFRCVVpzbGl2cFhLRE5aVGc2aW5DSHdyTGMiLAogICAgInkiOiAiOEY4TG5RN3dHOWh4c1Q0YXgwQXR5N2lNR0l5aVlfWUdwM19xSVp6S28xQSIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
-      integration: "ewogICAgImt0eSI6ICJFQyIsCiAgICAidXNlIjogInNpZyIsCiAgICAiY3J2IjogIlAtMjU2IiwKICAgICJraWQiOiAiaXB2LWNvcmUtc3R1Yi0yLWZyb20tbWtqd2sub3JnIiwKICAgICJ4IjogImszOXVLYWNTdWtRQnJNWnJIRFRCVVpzbGl2cFhLRE5aVGc2aW5DSHdyTGMiLAogICAgInkiOiAiOEY4TG5RN3dHOWh4c1Q0YXgwQXR5N2lNR0l5aVlfWUdwM19xSVp6S28xQSIsCiAgICAiYWxnIjogIkVTMjU2Igp9"
-
-  IPVCore1PublicSigningJwkBase64Mapping:
-    Environment:
-      staging: "eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6ImtlMVRNRnFNb0Z5eHg1eXpOdFFRbGw0dk9yeHZUdFBKQ0huUzRqOHpoMlUiLCJ5IjoicURLX0g4QXpKS2FIbU1zaHg5TGp2LTB0ek5rV2EtSkVHUzJtZHRKUjFPQSJ9"
-      integration: "eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6IkJUUWdWQjU0RE9JcDU0eGRVSVg0SGtUX3pCdjZHdVdMV1RUTkdxMk15dEkiLCJ5IjoiTFFRamx5ZEtOMUhXZFJQcFBpalJObEJrbi1qaDgzZzBBUmIyNms2WVh1byJ9"
-      production: "eyJrdHkiOiJFQyIsImNydiI6IlAtMjU2IiwieCI6IlVQdlU1TlBtRUxyV2lXU01WZkREN0c4dTNFSllyeXFQSVo0Nlc5TUFsUmMiLCJ5Ijoicjc3RjItS1BocHZUSUdFV2d0NVNtYXZTdkJVSENxV1V4RDZSR19GSkhWayJ9"
-
-  IPVCoreStubRedirectURIMapping:
-    Environment:
-      dev: "http://localhost:8085/callback"
-      build: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
-      staging: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
-      integration: "https://di-ipv-core-stub.london.cloudapps.digital/callback"
-
-  IPVCore1RedirectURIMapping:
-    Environment:
-      staging: "https://identity.staging.account.gov.uk/credential-issuer/callback?id=driving-permit"
-      integration: "https://identity.integration.account.gov.uk/credential-issuer/callback?id=driving-permit"
-      production: "https://identity.account.gov.uk/credential-issuer/callback?id=driving-permit"
-
-  VerifiableCredentialIssuerMapping:
-    Environment:
-      dev: "https://review-d.dev.account.gov.uk"
-      build: "https://review-d.build.account.gov.uk"
-      staging: "https://review-d.staging.account.gov.uk"
-      integration: "https://review-d.integration.account.gov.uk"
-      production: "https://review-d.account.gov.uk"
 
   DrivingPermitCriAudienceMapping:
     Environment:
@@ -279,6 +219,20 @@ Resources:
       EndpointConfiguration:
         Type: REGIONAL
 
+  PublicDrivingPermitApiAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PublicDrivingPermitApi}-public-AccessLogs
+      RetentionInDays: 365
+
+  PublicDrivingPermitApiAccessLogGroupSubscriptionFilterCsls:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      FilterPattern: ""
+      LogGroupName: !Ref PublicDrivingPermitApiAccessLogGroup
+
   PrivateDrivingPermitApi:
     Type: AWS::Serverless::Api
     Properties:
@@ -342,103 +296,19 @@ Resources:
                     - vpce-082cab7c78139eb54
                     - !ImportValue cri-vpc-ApiGatewayVpcEndpointId
 
-  PublicDrivingPermitApiAccessLogGroup:
+  PrivateDrivingPermitApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PublicDrivingPermitApi}-public-AccessLogs
       RetentionInDays: 365
 
-#  PublicDrivingPermitApiAccessLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDevEnvironment
-#    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-#      FilterPattern: ""
-#      LogGroupName: !Ref PublicDrivingPermitApiAccessLogGroup
-
-  PrivateDrivingPermitApiAccessLogGroup:
-    Type: AWS::Logs::LogGroup
+  PrivateDrivingPermitApiAccessLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
     Properties:
-      LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-${PrivateDrivingPermitApi}-private-AccessLogs
-      RetentionInDays: 365
-
-#  PrivateDrivingPermitApiAccessLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDevEnvironment
-#    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-#      FilterPattern: ""
-#      LogGroupName: !Ref PrivateDrivingPermitApiAccessLogGroup
-
-####################################################################
-#                                                                  #
-# Session Function                                                 #
-#                                                                  #
-####################################################################
-
-  SessionFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: ../../common-lambdas/session
-      Handler: uk.gov.di.ipv.cri.common.api.handler.SessionHandler::handleRequest
-      Environment:
-        Variables:
-          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-driving-permit-api
-          POWERTOOLS_SERVICE_NAME: di-ipv-cri-driving-permit-api-session
-          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
-      Policies:
-        - AWSLambdaBasicExecutionRole
-        - AWSXrayWriteOnlyAccess
-        - DynamoDBWritePolicy:
-            TableName:
-              Ref: SessionTable
-        - DynamoDBWritePolicy:
-            TableName:
-              Ref: PersonIdentityTable
-        - SQSSendMessagePolicy:
-            QueueName: !ImportValue AuditEventQueueName
-        - KMSDecryptPolicy:
-            KeyId: !ImportValue core-infrastructure-CriDecryptionKey1Id
-        - Statement:
-            - Effect: Allow
-              Action:
-                - ssm:GetParameter
-              Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTtl"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DrivingPermitCriAudience"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/PersonIdentityTableName"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/verifiable-credential/issuer"
-        - Statement:
-            - Effect: Allow
-              Action:
-                - ssm:GetParametersByPath
-              Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
-        - Statement:
-            - Sid: auditEventQueueKmsEncryptionKeyPermission
-              Effect: Allow
-              Action:
-                - 'kms:Decrypt'
-                - 'kms:GenerateDataKey'
-              Resource:
-                - !ImportValue AuditEventQueueEncryptionKeyArn
-
-#  SessionFunctionLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDevEnvironment
-#    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-#      FilterPattern: ""
-#      LogGroupName: !Sub "/aws/lambda/${SessionFunction}"
-
-  SessionFunctionPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !GetAtt SessionFunction.Arn
-      Principal: apigateway.amazonaws.com
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      FilterPattern: ""
+      LogGroupName: !Ref PublicDrivingPermitApiAccessLogGroup
 
 ####################################################################
 #                                                                  #
@@ -453,21 +323,18 @@ Resources:
       Handler: uk.gov.di.ipv.cri.drivingpermit.api.handler.DrivingPermitHandler::handleRequest
       Environment:
         Variables:
-          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-driving-permit-api
-          POWERTOOLS_SERVICE_NAME: di-ipv-cri-driving-permit-api-drivingpermitcheck
-          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
-          ENVIRONMENT: !Ref Environment
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-drivingpermitcheck"
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
         - DynamoDBWritePolicy:
-            TableName: !Ref SessionTable
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
         - DynamoDBReadPolicy:
-            TableName: !Ref SessionTable
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
         - DynamoDBReadPolicy:
-            TableName: !Ref PersonIdentityTable
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - DynamoDBWritePolicy:
-            TableName: !Ref PersonIdentityTable
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - DynamoDBWritePolicy:
             TableName: !Ref DocumentCheckResultTable
         - Statement:
@@ -476,8 +343,6 @@ Resources:
               Action:
                 - 'ssm:GetParameter*'
               Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Environment}/credentialIssuers/driving-permit*'
-        - SSMParameterReadPolicy:
-            ParameterName: !Sub "${AWS::StackName}/verifiable-credential/issuer"
         - Statement:
             - Sid: ReadSecretsPolicy
               Effect: Allow
@@ -503,8 +368,9 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/contraindicationMappings"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTtl"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTtl"
         - Statement:
             - Effect: Allow
               Action:
@@ -544,17 +410,14 @@ Resources:
       CodeUri: ../../lambdas/issuecredential
       Environment:
         Variables:
-          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-driving-permit-api
-          POWERTOOLS_SERVICE_NAME: di-ipv-cri-driving-permit-api-issuecredential
-          SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
-          ENVIRONMENT: !Ref Environment
+          POWERTOOLS_SERVICE_NAME: !Sub "{CriIdenitifier}-issuecredential"
       Policies:
         - AWSLambdaBasicExecutionRole
         - AWSXrayWriteOnlyAccess
         - DynamoDBReadPolicy:
-            TableName: !Ref SessionTable
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
         - DynamoDBReadPolicy:
-            TableName: !Ref PersonIdentityTable
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - DynamoDBReadPolicy:
             TableName: !Ref DocumentCheckResultTable
         - Statement:
@@ -565,7 +428,7 @@ Resources:
         - SQSSendMessagePolicy:
             QueueName: !ImportValue AuditEventQueueName
         - SSMParameterReadPolicy:
-            ParameterName: !Sub "${AWS::StackName}/*"
+            ParameterName: !Sub "${AWS::StackName}/*" # TODO: explicitly specify the parameter names in the same way as the DrivingPermitCheckingFunction
         - Statement:
             Effect: Allow
             Action:
@@ -574,6 +437,7 @@ Resources:
             Resource:
               - !ImportValue AuditEventQueueEncryptionKeyArn
 
+<<<<<<< HEAD
 #  IssueCredentialFunctionLogGroupSubscriptionFilter:
 #    Type: AWS::Logs::SubscriptionFilter
 #    Condition: IsNotDevEnvironment
@@ -587,102 +451,6 @@ Resources:
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt IssueCredentialFunction.Arn
-      Principal: apigateway.amazonaws.com
-
-####################################################################
-#                                                                  #
-# Access token Function                                            #
-#                                                                  #
-####################################################################
-
-  AccessTokenFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: ../../common-lambdas/accesstoken
-      Handler: uk.gov.di.ipv.cri.common.api.handler.AccessTokenHandler::handleRequest
-      Environment:
-        Variables:
-          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-driving-permit-api
-          POWERTOOLS_SERVICE_NAME: di-ipv-cri-driving-permit-api-access-token
-      Policies:
-        - DynamoDBCrudPolicy:
-            TableName:
-              Ref: SessionTable
-        - Statement:
-            - Effect: Allow
-              Action:
-                - ssm:GetParameter
-              Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTtl"
-        - Statement:
-            - Effect: Allow
-              Action:
-                - ssm:GetParametersByPath
-              Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
-
-#  AccessTokenFunctionLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDevEnvironment
-#    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-#      FilterPattern: ""
-#      LogGroupName: !Sub "/aws/lambda/${AccessTokenFunction}"
-
-  AccessTokenFunctionPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !GetAtt AccessTokenFunction.Arn
-      Principal: apigateway.amazonaws.com
-
-####################################################################
-#                                                                  #
-# Authorization Function                                           #
-#                                                                  #
-####################################################################
-
-  AuthorizationFunction:
-    Type: AWS::Serverless::Function
-    Properties:
-      CodeUri: ../../common-lambdas/authorization
-      Handler: uk.gov.di.ipv.cri.common.api.handler.AuthorizationHandler::handleRequest
-      Environment:
-        Variables:
-          POWERTOOLS_METRICS_NAMESPACE: di-ipv-cri-driving-permit-api
-          POWERTOOLS_SERVICE_NAME: di-ipv-cri-driving-permit-api-authorization
-      Policies:
-        - AWSLambdaBasicExecutionRole
-        - AWSXrayWriteOnlyAccess
-        - DynamoDBReadPolicy:
-            TableName: !Ref SessionTable
-        - Statement:
-            - Effect: Allow
-              Action:
-                - ssm:GetParameter
-              Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/SessionTableName"
-        - Statement:
-            - Effect: Allow
-              Action:
-                - ssm:GetParametersByPath
-              Resource:
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/clients/*"
-
- # AuthorizationFunctionLogGroupSubscriptionFilter:
- #   Type: AWS::Logs::SubscriptionFilter
- #   Condition: IsNotDevEnvironment
- #   Properties:
- #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
- #     FilterPattern: ""
- #     LogGroupName: !Sub "/aws/lambda/${AuthorizationFunction}"
-
-  AuthorizationFunctionPermission:
-    Type: AWS::Lambda::Permission
-    Properties:
-      Action: lambda:InvokeFunction
-      FunctionName: !GetAtt AuthorizationFunction.Arn
       Principal: apigateway.amazonaws.com
 
 ####################################################################
@@ -703,62 +471,6 @@ Resources:
         - AttributeName: "sessionId"
           KeyType: "HASH"
 
-  SessionTable:
-    Type: "AWS::DynamoDB::Table" # enable encryption with customer managed kms key. Will need new kms key
-    Properties:
-      TableName: !Sub "session-${AWS::StackName}"
-      BillingMode: "PAY_PER_REQUEST"
-      AttributeDefinitions:
-        - AttributeName: "sessionId"
-          AttributeType: "S"
-        - AttributeName: "authorizationCode"
-          AttributeType: "S"
-        - AttributeName: "accessToken"
-          AttributeType: "S"
-      KeySchema:
-        - AttributeName: "sessionId"
-          KeyType: "HASH"
-      GlobalSecondaryIndexes:
-        - IndexName: "authorizationCode-index"
-          KeySchema:
-            - AttributeName: "authorizationCode"
-              KeyType: "HASH"
-          Projection:
-            NonKeyAttributes:
-              - "sessionId"
-              - "redirectUri"
-              - "clientId"
-            ProjectionType: "INCLUDE"
-        - IndexName: "access-token-index"
-          KeySchema:
-            - AttributeName: "accessToken"
-              KeyType: "HASH"
-          Projection:
-            NonKeyAttributes:
-              - "sessionId"
-              - "subject"
-            ProjectionType: "INCLUDE"
-      TimeToLiveSpecification:
-        AttributeName: expiryDate
-        Enabled: true
-
-  PersonIdentityTable:
-    Type: "AWS::DynamoDB::Table" # enable encryption with customer managed kms key. Will need new kms key
-    Properties:
-      TableName: !Sub "person-identity-${AWS::StackName}"
-      BillingMode: "PAY_PER_REQUEST"
-      PointInTimeRecoverySpecification:
-        PointInTimeRecoveryEnabled: true
-      AttributeDefinitions:
-        - AttributeName: "sessionId"
-          AttributeType: "S"
-      KeySchema:
-        - AttributeName: "sessionId"
-          KeyType: "HASH"
-      TimeToLiveSpecification:
-        AttributeName: expiryDate
-        Enabled: true
-
 ####################################################################
 #                                                                  #
 # API config                                                 #
@@ -767,6 +479,7 @@ Resources:
 
   PublicDrivingPermitApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
+    Condition: IsNotDevEnvironment
     DependsOn:
       - PublicDrivingPermitApiStage
     Properties:
@@ -782,6 +495,7 @@ Resources:
 
   PrivateDrivingPermitApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
+    Condition: IsNotDevEnvironment
     DependsOn:
       - PrivateDrivingPermitApiStage
     Properties:
@@ -796,16 +510,16 @@ Resources:
         RateLimit: 50 # allowed requests per second
 
   LinkUsagePlanApiKey1:
-    Condition: IsNotDevEnvironment
     Type: AWS::ApiGateway::UsagePlanKey
+    Condition: IsNotDevEnvironment
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey1
       KeyType: API_KEY
       UsagePlanId: !Ref PublicDrivingPermitApiUsagePlan
 
   LinkUsagePlanApiKey2:
-    Condition: IsNotDevEnvironment
     Type: AWS::ApiGateway::UsagePlanKey
+    Condition: IsNotDevEnvironment
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey2
       KeyType: API_KEY
@@ -817,14 +531,6 @@ Resources:
 #                                                                  #
 ####################################################################
 
-  ParameterSessionTableName:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/SessionTableName"
-      Value: !Sub session-${AWS::StackName}
-      Type: String
-      Description: session dynamodb table name
-
   ParameterDocumentCheckResultTableName:
     Type: AWS::SSM::Parameter
     Properties:
@@ -832,14 +538,6 @@ Resources:
       Value: !Sub document-check-${AWS::StackName}
       Type: String
       Description: Document check result dynamodb table name
-
-  ParameterPersonIdentityTableName:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/PersonIdentityTableName"
-      Value: !Sub person-identity-${AWS::StackName}
-      Type: String
-      Description: person identity dynamodb table name
 
   MaxJwtTtlParameter:
     Type: AWS::SSM::Parameter
@@ -849,94 +547,6 @@ Resources:
       Value: !FindInMap [MaxJwtTtlMapping, Environment, !Ref 'Environment']
       Description: default time to live for an JWT in (seconds)
 
-  SessionTtlParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/SessionTtl"
-      Type: String
-      Value: !FindInMap [ SessionTtlMapping, Environment, !Ref 'Environment' ]
-      Description: default time to live for an driving permit session item (seconds)
-
-  IPVCoreStubAuthenticationAlgParameter:
-    Condition: IsStubEnvironment
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub/jwtAuthentication/authenticationAlg"
-      Type: String
-      Value: !FindInMap [IPVCoreStubAuthenticationAlgMapping, Environment, !Ref 'Environment']
-
-  IPVCore1AuthenticationAlgParameter:
-    Condition: IsProdLikeEnvironment
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/clients/ipv-core/jwtAuthentication/authenticationAlg"
-      Type: String
-      Value: !FindInMap [IPVCore1AuthenticationAlgMapping, Environment, !Ref 'Environment']
-
-  IPVCoreStubAudienceParameter:
-    Condition: IsStubEnvironment
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub/jwtAuthentication/audience"
-      Type: String
-      Value: !FindInMap [ IPVCoreStubAudienceMapping, Environment, !Ref 'Environment' ]
-
-  IPVCore1AudienceParameter:
-    Condition: IsProdLikeEnvironment
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/clients/ipv-core/jwtAuthentication/audience"
-      Type: String
-      Value: !FindInMap [ IPVCore1AudienceMapping, Environment, !Ref 'Environment' ]
-
-  IPVCoreStubIssuerParameter:
-    Condition: IsStubEnvironment
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub/jwtAuthentication/issuer"
-      Type: String
-      Value: !FindInMap [IPVCoreStubIssuerMapping, Environment, !Ref 'Environment']
-
-  IPVCore1IssuerParameter:
-    Condition: IsProdLikeEnvironment
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/clients/ipv-core/jwtAuthentication/issuer"
-      Type: String
-      Value: !FindInMap [IPVCore1IssuerMapping, Environment, !Ref 'Environment']
-
-  IPVCoreStubPublicSigningJwkBase64Parameter:
-    Condition: IsStubEnvironment
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub/jwtAuthentication/publicSigningJwkBase64"
-      Type: String
-      Value: !FindInMap [IPVCoreStubPublicSigningJwkBase64Mapping, Environment, !Ref 'Environment']
-
-  IPVCore1PublicSigningJwkBase64Parameter:
-    Condition: IsProdLikeEnvironment
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/clients/ipv-core/jwtAuthentication/publicSigningJwkBase64"
-      Type: String
-      Value: !FindInMap [IPVCore1PublicSigningJwkBase64Mapping, Environment, !Ref 'Environment']
-
-  IPVCoreStubRedirectURIParameter:
-    Condition: IsStubEnvironment
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/clients/ipv-core-stub/jwtAuthentication/redirectUri"
-      Type: String
-      Value: !FindInMap [IPVCoreStubRedirectURIMapping, Environment, !Ref 'Environment']
-
-  IPVCore1RedirectURIParameter:
-    Condition: IsProdLikeEnvironment
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/clients/ipv-core/jwtAuthentication/redirectUri"
-      Type: String
-      Value: !FindInMap [IPVCore1RedirectURIMapping, Environment, !Ref 'Environment']
-
   DrivingPermitCriAudienceParameter:
     Type: AWS::SSM::Parameter
     Properties:
@@ -944,30 +554,6 @@ Resources:
       Type: String
       Value: !FindInMap [DrivingPermitCriAudienceMapping, Environment, !Ref 'Environment']
       Description: The driving permit credential issuer (audience) identifier
-
-  AuthRequestKmsEncryptionKeyIdParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/AuthRequestKmsEncryptionKeyId"
-      Type: String
-      Value: !ImportValue core-infrastructure-CriDecryptionKey1Id
-      Description: The (KMS) encryption key identifier for decrypting authorisation requests
-
-  VerifiableCredentialIssuerParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/verifiable-credential/issuer"
-      Type: String
-      Value: !FindInMap [VerifiableCredentialIssuerMapping, Environment, !Ref 'Environment']
-      Description: Issuer of the Verifiable Credential
-
-  VerifiableCredentialKmsSigningKeyParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/verifiableCredentialKmsSigningKeyId"
-      Type: String
-      Value: !ImportValue core-infrastructure-CriVcSigningKey1Id
-      Description: Verifiable Credential Key Id
 
   LoggingKmsKey:
     Type: AWS::KMS::Key
@@ -1157,35 +743,17 @@ Outputs:
     Description: "CloudFormation stack name"
     Value: !Sub "${AWS::StackName}"
 
-  SessionApiUrl:
-    Description: "URL for the Driving Permit API /session resource"
-    Value: !Sub "https://${PublicDrivingPermitApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/session"
-    Export:
-      Name: !Sub ${AWS::StackName}-SessionApiUrl
-
   PublicDrivingPermitApiUrl:
     Description: "URL for the Driving Permit API /check-driving-licence resource"
     Value: !Sub "https://${PublicDrivingPermitApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/identity-check"
     Export:
       Name: !Sub ${AWS::StackName}-PublicDrivingPermitApiUrl
 
-  TokenApiUrl:
-    Description: "URL for the Driving Permit API /token resource"
-    Value: !Sub "https://${PublicDrivingPermitApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/token"
-    Export:
-      Name: !Sub ${AWS::StackName}-TokenApiUrl
-
   CredentialIssueApiUrl:
     Description: "URL for the Driving Permit API /credential/issue resource"
     Value: !Sub "https://${PublicDrivingPermitApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/credential/issue"
     Export:
       Name: !Sub ${AWS::StackName}-CredentialIssueApiUrl
-
-  JWKSetApiUrl:
-    Description: "URL for the Driving Permit API /.well-known/jwks.json resource"
-    Value: !Sub "https://${PublicDrivingPermitApi}.execute-api.${AWS::Region}.amazonaws.com/${Environment}/.well-known/jwks.json"
-    Export:
-      Name: !Sub ${AWS::StackName}-JWKSetApiUrl
 
   DrivingPermitApiBaseUrl:
     Description: "Base url of the Driving Permit CRI API, please reference the PublicDrivingPermitApiBaseUrl"

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/VerifiableCredentialService.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/VerifiableCredentialService.java
@@ -40,7 +40,8 @@ public class VerifiableCredentialService {
         this.signedJwtFactory =
                 new SignedJWTFactory(
                         new KMSSigner(
-                                configurationService.getVerifiableCredentialKmsSigningKeyId()));
+                                configurationService.getCommonParameterValue(
+                                        "verifiableCredentialKmsSigningKeyId")));
         this.objectMapper =
                 new ObjectMapper()
                         .registerModule(new Jdk8Module())

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,13 +10,5 @@ rootProject.name = "di-ipv-cri-driving-permit-api"
 // Internal CRI Lib
 include "lib"
 
-// Common lambdas
-include "session", "accesstoken", "jwkset", "authorization"
-project(':session').projectDir = new File('./common-lambdas/session')
-project(":accesstoken").projectDir = new File('./common-lambdas/accesstoken')
-project(':authorization').projectDir = new File('./common-lambdas/authorization')
-
 // CRI specific lambdas
-include "issuecredential", "drivingpermitcheck"
-project(':drivingpermitcheck').projectDir = new File('./lambdas/drivingpermitcheck')
-project(':issuecredential').projectDir = new File('./lambdas/issuecredential')
+include "lambdas:issuecredential", "lambdas:drivingpermitcheck"


### PR DESCRIPTION
### What changed
- Removed `common-lambdas` git submodules
- Added new parameter overrides to the pre-merge-integration-tests workflow
- Updated the private/public api configuration to refer to the new common lambda functions
- Removed common resources from template.yaml
- Updated template.yaml to refer to common resources where necessary
- Updated VerifiableCredentialService to refer to new common verifiableCredentialKmsSigningKeyId SSM parameter
- Updated `deploy.sh` parameter-overrides to enable the stack to be deployed to the shared dev account

### Why did it change
- To migrate to the common CRI framework and align with the kbv, address & fraud CRIs

### Issue tracking
- [OJ-999](https://govukverify.atlassian.net/browse/OJ-999)


[OJ-999]: https://govukverify.atlassian.net/browse/OJ-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ