### PR TITLE
LIME-243 - Extend VC Validity to 6 months

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -102,11 +102,11 @@ Mappings:
 
   MaxJwtTtlMapping:
     Environment:
-      dev: "7200" # 2 hrs
-      build: "7200"
-      staging: "7200"
-      integration: "7200"
-      production: "7200"
+      dev: "15780000" # 6 months
+      build: "15780000"
+      staging: "15780000"
+      integration: "15780000"
+      production: "15780000"
 
   IPVCoreStubAuthenticationAlgMapping:
     Environment:


### PR DESCRIPTION
## Proposed changes

### What changed

- Expiry time increased from 2 hours to 6 months

### Issue tracking

- [LIME-243](https://govukverify.atlassian.net/browse/LIME-243)

See also: https://github.com/alphagov/di-ipv-cri-fraud-api/pull/91