### PR TITLE
LIME-189 Capture DL CRI Metrics

### DIFF
--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/error/ErrorResponse.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/error/ErrorResponse.java
@@ -30,7 +30,8 @@ public enum ErrorResponse {
     DCS_ERROR_HTTP_30x(1022, "DCS Responded with a HTTP Redirection status code"),
     DCS_ERROR_HTTP_40x(1023, "DCS Responded with a HTTP Client Error status code"),
     DCS_ERROR_HTTP_50x(1024, "DCS Responded with a HTTP Server Error status code"),
-    DCS_ERROR_HTTP_X(1025, "DCS Responded with an unhandled HTTP status code");
+    DCS_ERROR_HTTP_X(1025, "DCS Responded with an unhandled HTTP status code"),
+    TOO_MANY_RETRY_ATTEMPTS(1026, "Too many retry attempts made");
 
     private final int code;
     private final String message;

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/gateway/ThirdPartyDocumentGatewayTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/gateway/ThirdPartyDocumentGatewayTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DcsPayload;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DcsResponse;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DocumentCheckResult;
@@ -66,17 +67,20 @@ class ThirdPartyDocumentGatewayTest {
         private final DcsCryptographyService dcsCryptographyService;
         private final ConfigurationService configurationService;
         private final HttpRetryer httpRetryer;
+        private final EventProbe eventProbe;
 
         private ExperianGatewayConstructorArgs(
                 ObjectMapper objectMapper,
                 DcsCryptographyService dcsCryptographyService,
                 ConfigurationService configurationService,
-                HttpRetryer httpRetryer) {
+                HttpRetryer httpRetryer,
+                EventProbe eventProbe) {
 
             this.objectMapper = objectMapper;
             this.dcsCryptographyService = dcsCryptographyService;
             this.httpRetryer = httpRetryer;
             this.configurationService = configurationService;
+            this.eventProbe = eventProbe;
         }
     }
 
@@ -91,6 +95,8 @@ class ThirdPartyDocumentGatewayTest {
     @Mock private HttpRetryer httpRetryer;
     @Mock private DcsCryptographyService dcsCryptographyService;
 
+    @Mock private EventProbe mockEventProbe;
+
     @BeforeEach
     void setUp() {
         lenient()
@@ -101,7 +107,8 @@ class ThirdPartyDocumentGatewayTest {
                         mockObjectMapper,
                         dcsCryptographyService,
                         configurationService,
-                        httpRetryer);
+                        httpRetryer,
+                        mockEventProbe);
     }
 
     @Test
@@ -361,11 +368,12 @@ class ThirdPartyDocumentGatewayTest {
         Map<String, ExperianGatewayConstructorArgs> testCases =
                 Map.of(
                         "objectMapper must not be null",
-                        new ExperianGatewayConstructorArgs(null, null, null, null),
+                        new ExperianGatewayConstructorArgs(null, null, null, null, null),
                         "crossCoreApiConfig must not be null",
                         new ExperianGatewayConstructorArgs(
                                 Mockito.mock(ObjectMapper.class),
                                 Mockito.mock(DcsCryptographyService.class),
+                                null,
                                 null,
                                 null));
 
@@ -378,7 +386,8 @@ class ThirdPartyDocumentGatewayTest {
                                                 constructorArgs.objectMapper,
                                                 constructorArgs.dcsCryptographyService,
                                                 constructorArgs.configurationService,
-                                                constructorArgs.httpRetryer),
+                                                constructorArgs.httpRetryer,
+                                                constructorArgs.eventProbe),
                                 errorMessage));
     }
 

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/IdentityVerificationServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DocumentCheckResult;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DocumentCheckVerificationResult;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.ValidationResult;
@@ -28,6 +29,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.DCS_CHECK_REQUEST_FAILED;
+import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.FORM_DATA_VALIDATION_FAIL;
+import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.FORM_DATA_VALIDATION_PASS;
 
 @ExtendWith(MockitoExtension.class)
 class IdentityVerificationServiceTest {
@@ -37,6 +41,7 @@ class IdentityVerificationServiceTest {
     @Mock private AuditService mockAuditService;
     @Mock private ConfigurationService configurationService;
     @Mock private ObjectMapper objectMapper;
+    @Mock private EventProbe mockEventProbe;
 
     private IdentityVerificationService identityVerificationService;
 
@@ -49,7 +54,8 @@ class IdentityVerificationServiceTest {
                         mockContraindicationMapper,
                         mockAuditService,
                         configurationService,
-                        objectMapper);
+                        objectMapper,
+                        mockEventProbe);
     }
 
     @Test
@@ -72,6 +78,7 @@ class IdentityVerificationServiceTest {
 
         assertNotNull(result);
         verify(formDataValidator).validate(drivingPermitForm);
+        verify(mockEventProbe).counterMetric(FORM_DATA_VALIDATION_PASS);
         verify(mockThirdPartyGateway).performDocumentCheck(drivingPermitForm);
     }
 
@@ -93,6 +100,8 @@ class IdentityVerificationServiceTest {
         final String EXPECTED_ERROR = String.valueOf(ErrorResponse.FORM_DATA_FAILED_VALIDATION);
 
         assertEquals(EXPECTED_ERROR, String.valueOf(e.getErrorResponse()));
+
+        verify(mockEventProbe).counterMetric(FORM_DATA_VALIDATION_FAIL);
     }
 
     @Test
@@ -112,5 +121,8 @@ class IdentityVerificationServiceTest {
         assertFalse(result.isVerified());
         assertEquals(
                 "Error occurred when attempting to invoke the third party api", result.getError());
+
+        verify(mockEventProbe).counterMetric(FORM_DATA_VALIDATION_PASS);
+        verify(mockEventProbe).counterMetric(DCS_CHECK_REQUEST_FAILED);
     }
 }

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ServiceFactoryTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ServiceFactoryTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.di.ipv.cri.common.library.service.AuditService;
+import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.drivingpermit.api.gateway.HttpRetryer;
 
 import java.security.InvalidKeyException;
@@ -26,12 +27,15 @@ class ServiceFactoryTest {
 
     @Mock private AuditService mockAuditService;
 
+    @Mock private EventProbe mockEventProbe;
+
     @Test
     void shouldCreateIdentityVerificationService()
             throws NoSuchAlgorithmException, InvalidKeyException {
         ServiceFactory serviceFactory =
                 new ServiceFactory(
                         mockObjectMapper,
+                        mockEventProbe,
                         mockConfigurationService,
                         mockDcsCryptographyService,
                         mockContraindicationMapper,

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/metrics/Definitions.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/metrics/Definitions.java
@@ -1,0 +1,57 @@
+package uk.gov.di.ipv.cri.drivingpermit.library.metrics;
+
+public class Definitions {
+
+    // Record all escape routes from the lambdas.
+    // OK for expected routes with ERROR being all others
+    public static final String LAMBDA_DRIVING_PERMIT_CHECK_COMPLETED_OK =
+            "lambda_driving_permit_check_completed_ok";
+    public static final String LAMBDA_DRIVING_PERMIT_CHECK_COMPLETED_ERROR =
+            "lambda_driving_permit_check_completed_error";
+
+    public static final String LAMBDA_ISSUE_CREDENTIAL_COMPLETED_OK =
+            "lambda_issue_credential_completed_ok";
+    public static final String LAMBDA_ISSUE_CREDENTIAL_COMPLETED_ERROR =
+            "lambda_issue_credential_completed_error";
+
+    // Document Status after an attempt
+    public static final String LAMBDA_DRIVING_PERMIT_CHECK_ATTEMPT_STATUS_VERIFIED_PREFIX =
+            "lambda_driving_permit_check_attempt_status_verified_"; // Attempt count appended
+    public static final String LAMBDA_DRIVING_PERMIT_CHECK_ATTEMPT_STATUS_RETRY =
+            "lambda_driving_permit_check_attempt_status_retry";
+    public static final String LAMBDA_DRIVING_PERMIT_CHECK_ATTEMPT_STATUS_UNVERIFIED =
+            "lambda_driving_permit_check_attempt_status_unverified";
+
+    // FormDataValidator
+    public static final String FORM_DATA_VALIDATION_PASS = "form_data_validation_pass";
+    public static final String FORM_DATA_VALIDATION_FAIL = "form_data_validation_fail";
+
+    // IssuingAuthority
+    public static final String ISSUING_AUTHORITY_PREFIX = "issuing_authority_";
+
+    // DCS
+    public static final String DCS_CHECK_REQUEST_SUCCEEDED = "dcs_check_request_succeeded";
+    public static final String DCS_CHECK_REQUEST_FAILED = "dcs_check_request_failed";
+
+    // VC Contra Indicators (CI is Appended)
+    public static final String DRIVING_PERMIT_CI_PREFIX = "driving_permit_ci_";
+
+    // HTTP Connection Send (Both)
+    public static final String THIRD_PARTY_REQUEST_CREATED = "third_party_requests_created";
+    public static final String THIRD_PARTY_REQUEST_SEND_RETRY = "third_party_requests_send_retry";
+    public static final String THIRD_PARTY_REQUEST_SEND_OK = "third_party_request_send_ok";
+    public static final String THIRD_PARTY_REQUEST_SEND_ERROR = "third_party_request_send_error";
+    public static final String THIRD_PARTY_REQUEST_SEND_MAX_RETRIES =
+            "third_party_request_send_max_retries";
+    public static final String THIRD_PARTY_REQUEST_SEND_FAIL =
+            "third_party_requests_send_fail"; // IOException
+
+    // Third Party Response Type DCS
+    public static final String THIRD_PARTY_DCS_RESPONSE_OK = "third_party_dcs_response_ok";
+    public static final String THIRD_PARTY_DCS_RESPONSE_TYPE_ERROR =
+            "third_party_dcs_response_type_error";
+
+    private Definitions() {
+        throw new IllegalStateException("Instantiation is not valid for this class.");
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/testdata/DocumentCheckTestDataGenerator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/testdata/DocumentCheckTestDataGenerator.java
@@ -15,7 +15,7 @@ public class DocumentCheckTestDataGenerator {
         DocumentCheckResultItem documentCheckResultItem = new DocumentCheckResultItem();
 
         documentCheckResultItem.setSessionId(UUID.randomUUID());
-        documentCheckResultItem.setContraIndicators(List.of(""));
+        documentCheckResultItem.setContraIndicators(List.of("CI1"));
 
         documentCheckResultItem.setStrengthScore(3);
         documentCheckResultItem.setValidityScore(2);


### PR DESCRIPTION
## Proposed changes

### What changed

Added metrics to DL CRI DrivingPermitCheck Lambda

DrivingPermitCheck - Completed ok/error
Issue Credential - Completed ok/error
PermitCheckStatus - Verified, Retry, Unverified
FormDataValidator - pass/fail
Issuing Authority - DVA/DVLA
DCS Check Request - succeeded/failed
DrivingPermitCheck Contra Indicators - generated
HTTP Connection Send - request_created/send_ok/send_retry/send_error/send_max_retries/send_fail
DCS Response Type Fraud - ok/error

Add unit tests for status of document after an attempt (Verified, Retry, Unverified)

### Why did it change

Metrics added to cover metrics requested for LIME-189

Definitions located in dl lib ...drivingpermit/library/metrics/Definitions.java.

### Issue tracking

- [LIME-189](https://govukverify.atlassian.net/browse/LIME-189)