### PR TITLE
LIME-173 send IPV_DRIVING_PERMIT_CRI_END audit event.

### DIFF
--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -68,4 +68,4 @@ jobs:
         if: always()
         run: |
           STACK_NAME=${{ env.STACK_NAME_PREFIX }}-${{ steps.vars.outputs.sha_short }}
-          sam delete --stack-name $STACK_NAME --region ${{ env.AWS_REGION }} --no-prompts
+          aws cloudformation delete-stack --region ${{ env.AWS_REGION }} --stack-name $STACK_NAME

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ ext {
 		nimbusds_jwt_version        : "9.15.1",
 		protobuf_version            : "3.19.4",
 		junit                       : "5.8.2",
-		mockito					    : "4.3.1",
-		cri_common_lib           	: "1.1.6"
+		mockito                     : "4.3.1",
+		cri_common_lib           	: "1.3.1"
 
 	]
 }

--- a/lambdas/issuecredential/build.gradle
+++ b/lambdas/issuecredential/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 			configurations.dynamodb,
 			configurations.jackson,
 			configurations.cri_common_lib,
-			configurations.sqs
+			configurations.sqs,
+			configurations.kms
 
 	aspect configurations.powertools
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/IssueCredentialHandler.java
@@ -131,6 +131,10 @@ public class IssueCredentialHandler
 
             LOGGER.info("Credential generated");
             eventProbe.counterMetric(LAMBDA_ISSUE_CREDENTIAL_COMPLETED_OK);
+
+            auditService.sendAuditEvent(
+                    AuditEventType.END, new AuditEventContext(input.getHeaders(), sessionItem));
+
             return ApiGatewayResponseGenerator.proxyJwtResponse(
                     HttpStatusCode.OK, signedJWT.serialize());
         } catch (AwsServiceException ex) {


### PR DESCRIPTION
(Merge after https://github.com/alphagov/di-ipv-cri-lib/pull/106)

## Proposed changes

### What changed

Send CRI_END audit event when VC is being returned.

Add kms to issuecredential dependancies.

Update CRI lib version to 1.3.1

### Why did it change

CRI_END audit event added per LIME-173.

Adding kms dependancy to issuecredential due to auto resolution failing with a locally generated cri lib.

CRI lib 1.3.1 contains the change needed.

### Issue tracking

- [LIME-173](https://govukverify.atlassian.net/browse/LIME-173)
