### PR TITLE
LIME-375: Driving Licence API test added to the structure

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -121,7 +121,7 @@ task cucumber() {
 				'--tags',
 				"${tags}",
 				'--glue',
-				'gov/di_ipv_fraud/step_definitions',
+				'gov/di_ipv_drivingpermit/step_definitions',
 				'src/test/resources' ,
 				'--plugin',
 				'html:build/test-results/cucmber.html',
@@ -142,7 +142,7 @@ task dlCriSmokeBuild() {
 				'--plugin',
 				'pretty',
 				'--glue',
-				'gov/di_ipv_fraud/step_definitions',
+				'gov/di_ipv_drivingpermit/step_definitions',
 				'src/test/resources/features/',
 				'--tags',
 				'@build'
@@ -161,7 +161,7 @@ task dlCriSmokeStaging() {
 				'--plugin',
 				'pretty',
 				'--glue',
-				'gov/di_ipv_fraud/step_definitions',
+				'gov/di_ipv_drivingpermit/step_definitions',
 				'src/test/resources/features/',
 				'--tags',
 				'@staging'

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/service/ConfigurationService.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/service/ConfigurationService.java
@@ -12,7 +12,6 @@ public class ConfigurationService {
     private final String coreStubEndpoint;
     private final String coreStubUsername;
     private final String coreStubPassword;
-    private final String passportCriUrl;
     private final String orchestratorStubUrl;
     private final String privateApiGatewayId;
     private final String environment;
@@ -27,7 +26,6 @@ public class ConfigurationService {
         this.coreStubEndpoint = getParameter("coreStubUrl");
         this.coreStubUsername = getParameter("coreStubUsername");
         this.coreStubPassword = getParameter("coreStubPassword");
-        this.passportCriUrl = getParameter("passportCriUrl");
         this.orchestratorStubUrl = getParameter("orchestratorStubUrl");
         this.privateApiGatewayId = getParameter("API_GATEWAY_ID_PRIVATE");
         this.environment = env;
@@ -52,10 +50,6 @@ public class ConfigurationService {
 
     public String getCoreStubPassword() {
         return coreStubPassword;
-    }
-
-    public String getPassportCriUrl() {
-        return passportCriUrl;
     }
 
     public String getOrchestratorStubUrl() {
@@ -89,10 +83,10 @@ public class ConfigurationService {
     }
 
     public String getDlCRITestEnvironment() {
-        String fraudCRITestEnvironment = this.environment;
-        if (fraudCRITestEnvironment == null) {
+        String dlCRITestEnvironment = this.environment;
+        if (dlCRITestEnvironment == null) {
             throw new IllegalArgumentException("Environment variable ENVIRONMENT is not set");
         }
-        return fraudCRITestEnvironment;
+        return dlCRITestEnvironment;
     }
 }

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -379,13 +379,13 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub "${AWS::StackName}/*"
 
-#  DrivingPermitCheckingFunctionLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDevEnvironment
-#    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-#      FilterPattern: ""
-#      LogGroupName: !Sub "/aws/lambda/${DrivingPermitCheckingFunction}"
+  DrivingPermitCheckingFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      FilterPattern: ""
+      LogGroupName: !Sub "/aws/lambda/${DrivingPermitCheckingFunction}"
 
   DrivingPermitCheckingFunctionPermission:
     Type: AWS::Lambda::Permission
@@ -427,6 +427,16 @@ Resources:
         - SSMParameterReadPolicy:
             ParameterName: !Sub "${AWS::StackName}/*" # TODO: explicitly specify the parameter names in the same way as the DrivingPermitCheckingFunction
         - Statement:
+            - Effect: Allow
+              Action:
+                - ssm:GetParameter
+              Resource:
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTtl"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/PersonIdentityTableName"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiableCredentialKmsSigningKeyId"
+          - Statement:
             Effect: Allow
             Action:
               - kms:Decrypt
@@ -434,13 +444,13 @@ Resources:
             Resource:
               - !ImportValue AuditEventQueueEncryptionKeyArn
 
-#  IssueCredentialFunctionLogGroupSubscriptionFilter:
-#    Type: AWS::Logs::SubscriptionFilter
-#    Condition: IsNotDevEnvironment
-#    Properties:
-#      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
-#      FilterPattern: ""
-#      LogGroupName: !Sub "/aws/lambda/${IssueCredentialFunction}"
+  IssueCredentialFunctionLogGroupSubscriptionFilter:
+    Type: AWS::Logs::SubscriptionFilter
+    Condition: IsNotDevEnvironment
+    Properties:
+      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+      FilterPattern: ""
+      LogGroupName: !Sub "/aws/lambda/${IssueCredentialFunction}"
 
   IssueCredentialFunctionPermission:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
Add BE Driving Licence tests to repo

Lime-375-Add-BE-Driving-Licence-tests-to-repo-1

Proposed changes
Add the Driving Licence API test to the repo

-(https://govukverify.atlassian.net/jira/software/c/projects/LIME/boards/239?modal=detail&selectedIssue=LIME-375)
