### PR TITLE
Updated test step that clicks on Driving Licence CRI

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -35,13 +35,13 @@ public class DrivingLicencePageObject extends UniversalSteps {
     public WebElement visitCredentialIssuers;
 
     @FindBy(xpath = "//*[@value=\"Driving Licence CRI Build\"]")
-    public WebElement drivingLicenceCDRIBuild;
+    public WebElement drivingLicenceCRIBuild;
 
     @FindBy(xpath = "//*[@value=\"Driving Licence CRI Staging\"]")
-    public WebElement drivingLicenceCDRIStaging;
+    public WebElement drivingLicenceCRIStaging;
 
     @FindBy(xpath = "//*[@value=\"Driving Licence CRI Integration\"]")
-    public WebElement drivingLicenceCDRIIntegration;
+    public WebElement drivingLicenceCRIIntegration;
 
     @FindBy(id = "licenceIssuerRadio-DVLA-label")
     public WebElement optionDVLA;
@@ -239,15 +239,15 @@ public class DrivingLicencePageObject extends UniversalSteps {
         assertURLContains("credential-issuers");
         switch (environment) {
             case "Build":
-                drivingLicenceCDRIBuild.click();
+                drivingLicenceCRIBuild.click();
                 break;
 
             case "Staging":
-                drivingLicenceCDRIStaging.click();
+                drivingLicenceCRIStaging.click();
                 break;
 
             case "Integration":
-                drivingLicenceCDRIIntegration.click();
+                drivingLicenceCRIIntegration.click();
                 break;
 
             default:
@@ -810,6 +810,21 @@ public class DrivingLicencePageObject extends UniversalSteps {
             LOGGER.info("Pass : Sorry, there is a problem page is displayed");
         } else {
             LOGGER.info("Fail : Who was your UK driving licence issued by? is displayed");
+        }
+    }
+
+    public void navigateToDrivingLicenceCRIOnTestEnv() {
+        visitCredentialIssuers.click();
+        String dlCRITestEnvironment = configurationService.getDlCRITestEnvironment();
+        LOGGER.info("dlCRITestEnvironment = " + dlCRITestEnvironment);
+        if (dlCRITestEnvironment.equalsIgnoreCase("Build")) {
+            drivingLicenceCRIBuild.click();
+        } else if (dlCRITestEnvironment.equalsIgnoreCase("Staging")) {
+            drivingLicenceCRIStaging.click();
+        } else if (dlCRITestEnvironment.equalsIgnoreCase("Integration")) {
+            drivingLicenceCRIIntegration.click();
+        } else {
+            LOGGER.info("No test environment is set");
         }
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DrivingLicenceStepDefs.java
@@ -152,4 +152,9 @@ public class DrivingLicenceStepDefs extends DrivingLicencePageObject {
     public void iDeleteTheCookieToGetTheUnexpectedError() {
         deleteCookie();
     }
+
+    @And("^I click the Driving Licence CRI for the testEnvironment$")
+    public void navigateToDrivingLicenceOnTestEnv() {
+        navigateToDrivingLicenceCRIOnTestEnv();
+    }
 }

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
@@ -2,13 +2,13 @@ Feature: DVA Driving Licence Test
 
   Background:
     Given I navigate to the IPV Core Stub
-    And I click the Driving Licence CRI for the Build environment
+    And I click the Driving Licence CRI for the testEnvironment
     And I search for Driving Licence user number 5 in the Experian table
     And I should be on `Who was your UK driving licence issued by` page
     And I click on DVA radio button and Continue
     And I should be on DVA `Enter your details exactly as they appear on your UK driving licence` page
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline:  DVA Driving Licence details page happy path
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -20,7 +20,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject             |
       |DVADrivingLicenceSubjectHappyBilly   |
 
-  @DVADrivingLicence_test #@build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence details page unhappy path with InvalidDVADrivingLicenceDetails
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -31,7 +31,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject      |
       |DVADrivingLicenceSubjectUnhappySelina |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence details page unhappy path with IncorrectDVADrivingLicenceNumber
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -45,7 +45,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject      |
       |IncorrectDVADrivingLicenceNumber |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence details page unhappy path with IncorrectDVADateOfBirth
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -58,7 +58,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectDVADateOfBirth |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence details page unhappy path with IncorrectDVAFirstName
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -71,7 +71,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectDVAFirstName|
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence details page unhappy path with IncorrectDVALastName
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -84,7 +84,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectDVALastName|
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence details page unhappy path with IncorrectDVAIssueDate
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -97,7 +97,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectDVAIssueDate|
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence details page unhappy path with IncorrectDVAValidToDate
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -110,7 +110,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectDVAValidToDate|
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence details page unhappy path with IncorrectDVAPostcode
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -123,7 +123,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectDVAPostcode|
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Retry Test Happy Path
     Given User enters invalid Driving Licence DVA details
     When User clicks on continue
@@ -137,7 +137,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVADrivingLicenceSubjectHappyBilly |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence User failed second attempt
     Given User enters invalid Driving Licence DVA details
     When User clicks on continue
@@ -151,7 +151,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |IncorrectDVADrivingLicenceNumber |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario: DVA Driving Licence User cancels after failed first attempt
     Given User enters invalid Driving Licence DVA details
     When User clicks on continue
@@ -161,14 +161,14 @@ Feature: DVA Driving Licence Test
     And JSON payload should contain ci DO2, validity score 0 and strength score 3
     And The test is complete and I close the driver
 
-  @DVADrivingLicence_test #@build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario: DVA Driving Licence User cancels before first attempt via prove your identity another way route
     Given User click on ‘prove your identity another way' Link
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
 
-  @DVADrivingLicence_test #@build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario: DVA Driving Licence User cancels before first attempt via I do not have a UK driving licence route
     Given User click on ‘Back' Link
     When User click on I do not have a UK driving licence radio button
@@ -177,7 +177,7 @@ Feature: DVA Driving Licence Test
     And The test is complete and I close the driver
 
 ###########  DVA Field Validations ##########
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Last name with numbers error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -188,7 +188,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject      |
       |InvalidDVALastNameWithNumbers |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Last name with special characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -199,7 +199,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |InvalidDVALastNameWithSpecialChar |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence No Last name in the Last name field error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -210,7 +210,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |NoDVALastName |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence First name with numbers error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -221,7 +221,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject      |
       |InvalidDVAFirstNameWithNumbers |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence First name with special characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -232,7 +232,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |InvalidDVAFirstNameWithSpecialChar |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence No First name in the First name field error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -243,7 +243,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |NoDVAFirstName |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Date of birth that are not real error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -254,7 +254,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |InvalidDVADateOfBirth |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Date of birth with special characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -265,7 +265,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVADOBWithSpecialCharacters |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Date of birth in the future error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -276,7 +276,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVADateOfBirthInFuture |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence - No Date in the Date of birth field error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -287,7 +287,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |NoDVADateOfBirth |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Issue date that are not real error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -298,7 +298,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVAInvalidIssueDate |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Issue date with special characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -309,7 +309,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVAIssueDateWithSpecialChar |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Issue date in the future error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -320,7 +320,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVAIssueDateInFuture |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence - No date in the Issue date field error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -331,7 +331,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |NoDVAIssueDate |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Valid to date that are not real error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -342,7 +342,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVAInvalidValidToDate |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Valid to date with special characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -353,7 +353,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVAValidToDateWithSpecialChar |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Valid to date in the past error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -364,7 +364,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVAValidToDateInPast |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence - No date in the Valid to date field error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -375,7 +375,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |NoDVAValidToDate |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence number less than 8 characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -386,7 +386,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVADrivingLicenceNumLessThan8Char |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence number with special characters and spaces error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -397,7 +397,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVADrivingLicenceNumWithSpecialChar |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence number with alpha numeric characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -408,7 +408,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVADrivingLicenceNumWithAlphanumericChar |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence number with alpha characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -419,7 +419,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVADrivingLicenceNumberWithAlphaChar |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence - No Licence number in the Licence number field error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -430,7 +430,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |NoDVADrivingLicenceNumber |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Postcode less than 5 characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -441,7 +441,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVAPostcodeLessThan5Char |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Postcode with special characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -452,7 +452,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVAPostcodeWithSpecialChar |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Postcode with numeric characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -463,7 +463,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVAPostcodeWithNumericChar |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence Postcode with alpha characters error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -474,7 +474,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |DVAPostcodeWithAlphaChar |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence - No Postcode in the Postcode field error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -485,7 +485,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject |
       |NoDVAPostcode |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline: DVA Driving Licence International Postcode error validation
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
@@ -496,7 +496,7 @@ Feature: DVA Driving Licence Test
       |DVADrivingLicenceSubject      |
       |DVAInternationalPostcode |
 
-  @DVADrivingLicence_test @build
+  @DVADrivingLicence_test @build @staging @integration
   Scenario Outline:  DVA Driving Licence Generate VC with invalid DL number and prove in another way unhappy path
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -2,13 +2,13 @@ Feature: Driving Licence Test
 
   Background:
     Given I navigate to the IPV Core Stub
-    And I click the Driving Licence CRI for the Build environment
+    And I click the Driving Licence CRI for the testEnvironment
     And I search for Driving Licence user number 5 in the Experian table
     And I should be on `Who was your UK driving licence issued by` page
     And I click on DVLA radio button and Continue
     And I should be on `Enter your details exactly as they appear on your UK driving licence` page
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-165
+  @DVLADrivingLicence_test @tmsLink=LIME-165 @build @staging @integration
   Scenario Outline:  DVLA Driving Licence details page happy path
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -20,7 +20,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject             |
       |DrivingLicenceSubjectHappyPeter   |
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-165
+  @DVLADrivingLicence_test @tmsLink=LIME-165 @build @staging @integration
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectDrivingLicenceNumber
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -34,7 +34,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject      |
       |IncorrectDrivingLicenceNumber |
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-165
+  @DVLADrivingLicence_test @tmsLink=LIME-165 @build @staging @integration
   Scenario Outline: DVLA Driving Licence details page unhappy path when licence number date format does not match with User's Date Of Birth
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -45,7 +45,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject      |
       |InvalidDrivingLicenceNumber |
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-165
+  @DVLADrivingLicence_test @tmsLink=LIME-165 @build @staging @integration
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectDateOfBirth
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -56,7 +56,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectDateOfBirth |
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-165
+  @DVLADrivingLicence_test @tmsLink=LIME-165 @build @staging @integration
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectFirstName
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -69,7 +69,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectFirstName|
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-165
+  @DVLADrivingLicence_test @tmsLink=LIME-165 @build @staging @integration
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectLastName
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -82,7 +82,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject      |
       |IncorrectLastName|
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-165
+  @DVLADrivingLicence_test @tmsLink=LIME-165 @build @staging @integration
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectIssueDate
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -95,7 +95,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectIssueDate|
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-165
+  @DVLADrivingLicence_test @tmsLink=LIME-165 @build @staging @integration
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectValidToDate
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -108,7 +108,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectValidToDate|
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-165
+  @DVLADrivingLicence_test @tmsLink=LIME-165 @build @staging @integration
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectIssueNumber
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -121,7 +121,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectIssueNumber|
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-165
+  @DVLADrivingLicence_test @tmsLink=LIME-165 @build @staging @integration
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectPostcode
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -134,7 +134,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectPostcode|
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-167
+  @DVLADrivingLicence_test @tmsLink=LIME-167 @build @staging @integration
   Scenario Outline: DVLA Driving Licence Retry Test Happy Path
     Given User enters invalid Driving Licence DVLA details
     When User clicks on continue
@@ -148,7 +148,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject             |
       |DrivingLicenceSubjectHappyPeter |
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-167
+  @DVLADrivingLicence_test @tmsLink=LIME-167 @build @staging @integration
   Scenario Outline: DVLA Driving Licence User failed second attempt
     Given User enters invalid Driving Licence DVLA details
     When User clicks on continue
@@ -162,7 +162,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IncorrectDrivingLicenceNumber |
 
-  @DVLADrivingLicence_test @build @tmsLink=LIME-167
+  @DVLADrivingLicence_test @tmsLink=LIME-167 @build @staging @integration
   Scenario: DVLA Driving Licence User cancels after failed first attempt
     Given User enters invalid Driving Licence DVLA details
     When User clicks on continue
@@ -172,14 +172,14 @@ Feature: Driving Licence Test
     And JSON payload should contain ci DO2, validity score 0 and strength score 3
     And The test is complete and I close the driver
 
-  @DVLADrivingLicence_test @tmsLink=LIME-167 #@build
+  @DVLADrivingLicence_test @tmsLink=LIME-167 @build @staging @integration
   Scenario: DVLA Driving Licence User cancels before first attempt via prove your identity another way route
     Given User click on ‘prove your identity another way' Link
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
 
-  @DVLADrivingLicence_test @tmsLink=LIME-167 #@build
+  @DVLADrivingLicence_test @tmsLink=LIME-167 @build @staging @integration
   Scenario: DVLA Driving Licence User cancels before first attempt via I do not have a UK driving licence route
     Given User click on ‘Back' Link
     When User click on I do not have a UK driving licence radio button
@@ -188,7 +188,7 @@ Feature: Driving Licence Test
     And The test is complete and I close the driver
 
     ###########  DVLA Field Validations ##########
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Last name with numbers error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -199,7 +199,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject      |
       |InvalidLastNameWithNumbers |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Last name with special characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -210,7 +210,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |InvalidLastNameWithSpecialCharacters |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence - No Last name in the Last name field error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -221,7 +221,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |NoLastName |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence First name with numbers error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -232,7 +232,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject      |
       |InvalidFirstNameWithNumbers |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence First name with special characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -243,7 +243,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |InvalidFirstNameWithSpecialCharacters |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence - No First name in the First name field error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -254,7 +254,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |NoFirstName |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Middle names with numbers error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -265,7 +265,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject      |
       |InvalidMiddleNamesWithNumbers |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Middle names with special characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -276,7 +276,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject      |
       |InvalidMiddleNamesWithSpecialCharacters |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Date of birth that are not real error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -287,7 +287,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |InvalidDateOfBirth |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Date of birth with special characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -298,7 +298,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |DateOfBirthWithSpecialCharacters |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Date of birth in the future error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -309,7 +309,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |DateOfBirthInFuture |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence - No Date in the Date of birth field error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -320,7 +320,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |NoDateOfBirth |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Issue date that are not real error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -331,7 +331,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |InvalidIssueDate |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Issue date with special characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -342,7 +342,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IssueDateWithSpecialCharacters |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Issue date in the future error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -353,7 +353,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IssueDateInFuture |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence - No date in the Issue date field error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -364,7 +364,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |NoIssueDate |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Valid to date that are not real error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -375,7 +375,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |InvalidValidToDate |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Valid to date with special characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -386,7 +386,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |ValidToDateWithSpecialCharacters |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Valid to date in the past error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -397,7 +397,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |ValidToDateInPast |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence - No date in the Valid to date field error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -408,7 +408,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |NoValidToDate |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence number less than 16 characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -419,7 +419,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject      |
       |DrivingLicenceNumLessThan16Char |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence number with special characters and spaces error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -430,7 +430,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |DrivingLicenceNumberWithSpecialChar |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence number with numeric characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -441,7 +441,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |DrivingLicenceNumberWithNumericChar |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence number with alpha characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -452,7 +452,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |DrivingLicenceNumberWithAlphaChar |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence - No Licence number in the Licence number field error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -463,7 +463,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |NoDrivingLicenceNumber |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Issue number less than 2 characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -474,7 +474,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IssueNumberLessThan2Char |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Issue number with special characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -485,7 +485,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IssueNumberWithSpecialChar |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Issue number with alphanumeric characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -496,7 +496,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IssueNumberWithAlphanumericChar |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Issue number with alpha characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -507,7 +507,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |IssueNumberWithAlphaChar |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence - No Issue number in the Issue number field error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -518,7 +518,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |NoIssueNumber |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Postcode less than 5 characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -529,7 +529,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |PostcodeLessThan5Char |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Postcode with special characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -540,7 +540,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |PostcodeWithSpecialChar |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Postcode with numeric characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -551,7 +551,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |PostcodeWithNumericChar |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence Postcode with alpha characters error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -562,7 +562,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |PostcodeWithAlphaChar |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence - No Postcode in the Postcode field error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -573,7 +573,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |NoPostcode |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline: DVLA Driving Licence International Postcode error validation
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue
@@ -584,7 +584,7 @@ Feature: Driving Licence Test
       |DrivingLicenceSubject |
       |InternationalPostcode |
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario Outline:  DVLA Driving Licence Generate VC with invalid DL number and prove in another way unhappy path
     Given User enters data as a <DrivingLicenceSubject>
     When User clicks on continue

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicense.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicense.feature
@@ -1,13 +1,13 @@
 Feature: Driving License Test
 
- Background: @happy_path @build
+ Background:
     Given I navigate to the IPV Core Stub
-    And I click the Driving Licence CRI for the Build environment
+    And I click the Driving Licence CRI for the testEnvironment
     Then I search for Driving Licence user number 5 in the Experian table
     Then I check the page title who was your UK driving license issued by?
     And I assert the URL is valid
 
- @DrivingLicenceTest
+ @DrivingLicenceTest @build @staging @integration
   Scenario:3 options and Radio button available in Driving Licence page
     Given I can see a radio button titled “DVLA”
     Then I can see a radio button titled “DVA”
@@ -15,19 +15,19 @@ Feature: Driving License Test
     Then I can see CTA "continue"
     And The test is complete and I close the driver
 
-  @DrivingLicenceTest
+  @DrivingLicenceTest @build @staging @integration
   Scenario:User Selects DVLA and landed in DVLA page
     Given I click on DVLA radio button and Continue
     Then I should on the page DVLA Enter your details exactly as they appear on your UK driving licence
     And The test is complete and I close the driver
 
-  @DrivingLicenceTest
+  @DrivingLicenceTest @build @staging @integration
   Scenario:User Selects DVA and landed in DVA page
     Given I click on DVA radio button and Continue
     Then I should be on the page DVA Enter your details exactly as they appear on your UK driving licence
     And The test is complete and I close the driver
 
-  @DrivingLicenceTest
+  @DrivingLicenceTest @build @staging @integration
   Scenario:User selects no Driving Licence and landed in IPV Core
     Given I click I do not have UK Driving License and continue
     When I am directed to the IPV Core routing page
@@ -36,7 +36,7 @@ Feature: Driving License Test
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
 
-  @DrivingLicenceTest
+  @DrivingLicenceTest @build @staging @integration
   Scenario: User continue with no selection and see the error displayed
     Given I have not selected anything and Continue
     When I can see an error box highlighted red
@@ -45,7 +45,7 @@ Feature: Driving License Test
     And The field error copy “You must choose an option to continue”
     And The test is complete and I close the driver
 
-  @DVLADrivingLicence_test @build
+  @DVLADrivingLicence_test @build @staging @integration
   Scenario: Check the Unrecoverable error/ Unknown error in Driving Licence CRI
     Given I delete the cookie to get the unexpected error
     When I can see the relevant error page with correct title


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes
These changes have been done as part of this ticket : https://govukverify.atlassian.net/browse/LIME-453
The test step "I click the Driving Licence CRI for the 'Build' environment" has been removed from the driving licence tests and has been replaced with the test step 'I click the Driving Licence CRI for the testEnvironment'. This is so that the test environment details are passed in the environment variables and not specified on the test step. This is to avoid duplication of tests.
### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks