### PR TITLE
LIME-529 - Pinned gradle version 7.6

### DIFF
--- a/.github/workflows/dailyDLSmokeTest.yml
+++ b/.github/workflows/dailyDLSmokeTest.yml
@@ -26,6 +26,10 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
+      - uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.3
+
       - name: Run Driving Licence Smoke test against build environment
         env:
           BROWSER: chrome-headless

--- a/.github/workflows/gradleBuildTest.yml
+++ b/.github/workflows/gradleBuildTest.yml
@@ -25,6 +25,10 @@ jobs:
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 
+      - uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.3
+
       - name: Run Driving Licence Smoke test against build environment
         env:
           BROWSER: chrome-headless

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -27,6 +27,10 @@ jobs:
           java-version: 11
           distribution: zulu
 
+      - uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.3
+
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v1
 

--- a/.github/workflows/post-merge-package-for-build.yml
+++ b/.github/workflows/post-merge-package-for-build.yml
@@ -27,6 +27,10 @@ jobs:
           java-version: 11
           distribution: zulu
 
+      - uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.3
+
       - name: Setup SAM CLI
         uses: aws-actions/setup-sam@v1
 

--- a/.github/workflows/pre-merge-integration-test.yml
+++ b/.github/workflows/pre-merge-integration-test.yml
@@ -31,6 +31,10 @@ jobs:
           java-version: 11
           distribution: zulu
 
+      - uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.3
+
       - name: Setup SAM
         uses: aws-actions/setup-sam@v1
 

--- a/acceptance-tests/Dockerfile
+++ b/acceptance-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:jdk11
+FROM gradle:7.6.0-jdk11
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
 
 RUN apt-get update


### PR DESCRIPTION
### What changed

Pinned gradle version 7.6

### Why did it change

Codebase supports gradle version 7.6

