### PR TITLE
LIME-440 - Capture Driving Licence issuer in TxMA Audit Events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ subprojects {
 		maven {
 			url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
 		}
+		//		flatDir {
+		//			dirs '/PATH_TO_LIB/di-ipv-cri-lib/build/libs'
+		//		}
 	}
 
 	configurations {
@@ -106,6 +109,7 @@ subprojects {
 		test_runtime "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
 
 		cri_common_lib "uk.gov.account:cri-common-lib:${dependencyVersions.cri_common_lib}"
+		// cri_common_lib name: "cri-common-lib-1.4.1"
 
 	}
 	apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
 		protobuf_version            : "3.19.4",
 		junit                       : "5.8.2",
 		mockito                     : "4.3.1",
-		cri_common_lib           	: "1.3.1"
+		cri_common_lib           	: "1.4.2"
 
 	]
 }

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
@@ -156,7 +156,7 @@ public class DrivingPermitHandler
             result.setAttemptCount(sessionItem.getAttemptCount());
 
             auditService.sendAuditEvent(
-                    AuditEventType.THIRD_PARTY_REQUEST_ENDED,
+                    AuditEventType.RESPONSE_RECEIVED,
                     new AuditEventContext(headers, sessionItem),
                     "");
 

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/DocumentCheckPersonIdentityDetailedMapper.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/DocumentCheckPersonIdentityDetailedMapper.java
@@ -24,7 +24,10 @@ public class DocumentCheckPersonIdentityDetailedMapper {
         birthDate.setValue(drivingPermitData.getDateOfBirth());
 
         return new PersonIdentityDetailed(
-                List.of(name1), List.of(birthDate), drivingPermitData.getAddresses());
+                List.of(name1),
+                List.of(birthDate),
+                drivingPermitData.getAddresses(),
+                List.of(mapDrivingPermit(drivingPermitData)));
     }
 
     public static Name mapNamesToCanonicalName(List<String> forenames, String surname) {
@@ -50,5 +53,17 @@ public class DocumentCheckPersonIdentityDetailedMapper {
         namePart.setValue(value);
         namePart.setType(type);
         return namePart;
+    }
+
+    private static DrivingPermit mapDrivingPermit(DrivingPermitForm drivingPermitData) {
+        DrivingPermit drivingPermit = new DrivingPermit();
+
+        drivingPermit.setPersonalNumber(drivingPermitData.getDrivingLicenceNumber());
+        drivingPermit.setIssueNumber(drivingPermitData.getIssueNumber());
+        drivingPermit.setIssueDate(drivingPermitData.getIssueDate());
+        drivingPermit.setExpiryDate(drivingPermitData.getExpiryDate());
+        drivingPermit.setIssuedBy(drivingPermitData.getLicenceIssuer());
+
+        return drivingPermit;
     }
 }

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
@@ -109,9 +109,7 @@ class DrivingPermitHandlerTest {
         doNothing()
                 .when(auditService)
                 .sendAuditEvent(
-                        eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
-                        any(AuditEventContext.class),
-                        eq(""));
+                        eq(AuditEventType.RESPONSE_RECEIVED), any(AuditEventContext.class), eq(""));
 
         when(mockIdentityVerificationService.verifyIdentity(drivingPermitForm))
                 .thenReturn(testDocumentVerificationResult);
@@ -166,9 +164,7 @@ class DrivingPermitHandlerTest {
         doNothing()
                 .when(auditService)
                 .sendAuditEvent(
-                        eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
-                        any(AuditEventContext.class),
-                        eq(""));
+                        eq(AuditEventType.RESPONSE_RECEIVED), any(AuditEventContext.class), eq(""));
 
         when(mockIdentityVerificationService.verifyIdentity(drivingPermitForm))
                 .thenReturn(testDocumentVerificationResult);
@@ -232,9 +228,7 @@ class DrivingPermitHandlerTest {
         doNothing()
                 .when(auditService)
                 .sendAuditEvent(
-                        eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
-                        any(AuditEventContext.class),
-                        eq(""));
+                        eq(AuditEventType.RESPONSE_RECEIVED), any(AuditEventContext.class), eq(""));
 
         when(mockIdentityVerificationService.verifyIdentity(drivingPermitForm))
                 .thenReturn(testDocumentVerificationResult);
@@ -333,9 +327,7 @@ class DrivingPermitHandlerTest {
         doNothing()
                 .when(auditService)
                 .sendAuditEvent(
-                        eq(AuditEventType.THIRD_PARTY_REQUEST_ENDED),
-                        any(AuditEventContext.class),
-                        eq(""));
+                        eq(AuditEventType.RESPONSE_RECEIVED), any(AuditEventContext.class), eq(""));
 
         when(context.getFunctionName()).thenReturn("functionName");
         when(context.getFunctionVersion()).thenReturn("1.0");

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/DocumentCheckPersonIdentityDetailedMapper.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/DocumentCheckPersonIdentityDetailedMapper.java
@@ -1,9 +1,6 @@
 package uk.gov.di.ipv.cri.drivingpermit.api.util;
 
-import uk.gov.di.ipv.cri.common.library.domain.personidentity.BirthDate;
-import uk.gov.di.ipv.cri.common.library.domain.personidentity.Name;
-import uk.gov.di.ipv.cri.common.library.domain.personidentity.NamePart;
-import uk.gov.di.ipv.cri.common.library.domain.personidentity.PersonIdentityDetailed;
+import uk.gov.di.ipv.cri.common.library.domain.personidentity.*;
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.DrivingPermitForm;
 
 import java.util.ArrayList;
@@ -27,7 +24,10 @@ public class DocumentCheckPersonIdentityDetailedMapper {
         birthDate.setValue(drivingPermitData.getDateOfBirth());
 
         return new PersonIdentityDetailed(
-                List.of(name1), List.of(birthDate), drivingPermitData.getAddresses());
+                List.of(name1),
+                List.of(birthDate),
+                drivingPermitData.getAddresses(),
+                List.of(mapDrivingPermit(drivingPermitData)));
     }
 
     public static Name mapNamesToCanonicalName(List<String> forenames, String surname) {
@@ -53,5 +53,17 @@ public class DocumentCheckPersonIdentityDetailedMapper {
         namePart.setValue(value);
         namePart.setType(type);
         return namePart;
+    }
+
+    private static DrivingPermit mapDrivingPermit(DrivingPermitForm drivingPermitData) {
+        DrivingPermit drivingPermit = new DrivingPermit();
+
+        drivingPermit.setPersonalNumber(drivingPermitData.getDrivingLicenceNumber());
+        drivingPermit.setIssueNumber(drivingPermitData.getIssueNumber());
+        drivingPermit.setIssueDate(drivingPermitData.getIssueDate());
+        drivingPermit.setExpiryDate(drivingPermitData.getExpiryDate());
+        drivingPermit.setIssuedBy(drivingPermitData.getLicenceIssuer());
+
+        return drivingPermit;
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

- audit event support added for `drivingPermit` data

### Issue tracking

- [LIME-440](https://govukverify.atlassian.net/browse/LIME-440)

See also: https://github.com/alphagov/di-ipv-cri-lib/pull/193

[LIME-440]: https://govukverify.atlassian.net/browse/LIME-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/107932230/224102745-649ae597-4d50-47c7-bd20-d5e6ce661841.png">
<img width="1288" alt="image" src="https://user-images.githubusercontent.com/107932230/224104226-af6b5654-c555-49ae-9670-3b9ee71e5b3d.png">
