### PR TITLE
LIME-571 Return checkDetails and failedCheckDetails in an array

### DIFF
--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/domain/verifiablecredential/Evidence.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/domain/verifiablecredential/Evidence.java
@@ -35,11 +35,11 @@ public class Evidence {
 
     @JsonProperty("checkDetails")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private CheckDetails checkDetails;
+    private List<CheckDetails> checkDetails;
 
     @JsonProperty("failedCheckDetails")
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    private CheckDetails failedCheckDetails;
+    private List<CheckDetails> failedCheckDetails;
 
     @JsonProperty("ci")
     private List<String> ci;
@@ -84,19 +84,19 @@ public class Evidence {
         this.activityHistoryScore = activityHistoryScore;
     }
 
-    public CheckDetails getCheckDetails() {
+    public List<CheckDetails> getCheckDetails() {
         return checkDetails;
     }
 
-    public void setCheckDetails(CheckDetails checkDetails) {
+    public void setCheckDetails(List<CheckDetails> checkDetails) {
         this.checkDetails = checkDetails;
     }
 
-    public CheckDetails getFailedCheckDetails() {
+    public List<CheckDetails> getFailedCheckDetails() {
         return failedCheckDetails;
     }
 
-    public void setFailedCheckDetails(CheckDetails failedCheckDetails) {
+    public void setFailedCheckDetails(List<CheckDetails> failedCheckDetails) {
         this.failedCheckDetails = failedCheckDetails;
     }
 

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/EvidenceHelper.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/util/EvidenceHelper.java
@@ -5,6 +5,8 @@ import uk.gov.di.ipv.cri.drivingpermit.api.domain.verifiablecredential.EvidenceT
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.CheckDetails;
 import uk.gov.di.ipv.cri.drivingpermit.library.persistence.item.DocumentCheckResultItem;
 
+import java.util.List;
+
 public class EvidenceHelper {
 
     private EvidenceHelper() {
@@ -29,9 +31,9 @@ public class EvidenceHelper {
         evidence.setCi(documentCheckResultItem.getContraIndicators());
 
         if (null == evidence.getCi()) {
-            evidence.setCheckDetails(checkDetails);
+            evidence.setCheckDetails(List.of(checkDetails));
         } else {
-            evidence.setFailedCheckDetails(checkDetails);
+            evidence.setFailedCheckDetails(List.of(checkDetails));
         }
 
         return evidence;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Return checkDetails and failedCheckDetails in an array

### Why did it change

checkDetails and failedCheckDetails where incorrectly returned as single objects.

### Issue tracking

- [LIME-571](https://govukverify.atlassian.net/browse/LIME-571)
