### PR TITLE
LIME-443 Update tests to handle confirmation of prove-another-way

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -106,6 +106,12 @@ public class DrivingLicencePageObject extends UniversalSteps {
     @FindBy(xpath = "//*[@id=\"main-content\"]/div/div/div/a")
     public WebElement proveAnotherWay;
 
+    @FindBy(id = "proveAnotherWayRadio")
+    public WebElement radioProveAnotherWay;
+
+    @FindBy(id = "proveAnotherWayRadio-proveAnotherWay-label")
+    public WebElement optionProveAnotherWay;
+
     @FindBy(id = "govuk-notification-banner-title")
     public WebElement errorText;
 

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
@@ -121,6 +121,13 @@ public class DVLAAndDVADrivingLicenceStepDefs extends DrivingLicencePageObject {
         proveAnotherWay.click();
     }
 
+    @Given("User selects `Prove your identity another way` and confirms")
+    public void clickOnProveYourIdentityAnotherWayRadioButton() {
+        optionProveAnotherWay.click();
+        radioProveAnotherWay.click();
+        CTButton.click();
+    }
+
     @When("User click on I do not have a UK driving licence radio button")
     public void selectIDoNotHaveAUKDrivingLicenceRadioButton() {
         clickOnIDoNotHaveAUKDrivingLicenceRadioButton();

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
@@ -158,6 +158,7 @@ Feature: DVA Driving Licence Test
     When User clicks on continue
     Then Proper error message for Could not find your details is displayed
     When User click on ‘prove your identity another way' Link
+    And User selects `Prove your identity another way` and confirms
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain ci DO2, validity score 0 and strength score 3
     And The test is complete and I close the driver
@@ -165,6 +166,7 @@ Feature: DVA Driving Licence Test
   @DVADrivingLicence_test @smoke
   Scenario: DVA Driving Licence User cancels before first attempt via prove your identity another way route
     Given User click on ‘prove your identity another way' Link
+    And User selects `Prove your identity another way` and confirms
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
@@ -502,6 +504,7 @@ Feature: DVA Driving Licence Test
     Given User enters DVA data as a <DVADrivingLicenceSubject>
     When User clicks on continue
     When User click on ‘prove your identity another way' Link
+    And User selects `Prove your identity another way` and confirms
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON response should contain documentNumber 88776655 same as given Driving Licence
     And The test is complete and I close the driver

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -168,6 +168,7 @@ Feature: Driving Licence Test
     When User clicks on continue
     Then Proper error message for Could not find your details is displayed
     When User click on ‘prove your identity another way' Link
+    And User selects `Prove your identity another way` and confirms
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain ci DO2, validity score 0 and strength score 3
     And The test is complete and I close the driver
@@ -175,6 +176,7 @@ Feature: Driving Licence Test
   @DVLADrivingLicence_test @smoke
   Scenario: DVLA Driving Licence User cancels before first attempt via prove your identity another way route
     Given User click on ‘prove your identity another way' Link
+    And User selects `Prove your identity another way` and confirms
     Then I navigate to the Driving Licence verifiable issuer to check for a Invalid response
     And JSON response should contain error description Authorization permission denied and status code as 302
     And The test is complete and I close the driver
@@ -589,6 +591,7 @@ Feature: Driving Licence Test
     Given User enters DVLA data as a <DrivingLicenceSubject>
     When User clicks on continue
     When User click on ‘prove your identity another way' Link
+    And User selects `Prove your identity another way` and confirms
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON response should contain documentNumber PARKE610112PBFGI same as given Driving Licence
     And The test is complete and I close the driver


### PR DESCRIPTION
## Proposed changes

### What changed

Updates the test to handle the confirmation page of prove another way

### Why did it change

Clicking prove another way now displays a page for confirmation before proceeding.

### Issue tracking

- [LIME-443](https://govukverify.atlassian.net/browse/LIME-443)
- https://github.com/alphagov/di-ipv-cri-dl-front/pull/96

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[LIME-443]: https://govukverify.atlassian.net/browse/LIME-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ