### PR TITLE
added tests for DVLA and DVA consent checkbox error validation

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DVAEnterYourDetailsExactlyPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DVAEnterYourDetailsExactlyPageObject.java
@@ -85,6 +85,11 @@ public class DVAEnterYourDetailsExactlyPageObject extends DrivingLicencePageObje
                     "//*[@class='govuk-error-summary error-summary']//*[@class='govuk-error-summary__body']//*[@class='govuk-list govuk-error-summary__list']//*[contains(@href,'#dvaLicenceNumber')]")
     public WebElement DVAInvalidDrivingLicenceErrorInSummary;
 
+    @FindBy(
+            xpath =
+                    "//*[@class='govuk-error-summary error-summary']//*[@class='govuk-error-summary__body']//*[@class='govuk-list govuk-error-summary__list']//*[contains(@href,'#consentDVACheckbox')]")
+    public WebElement DVAConsentErrorInSummary;
+
     // --------------------------
 
     // Field errors
@@ -103,6 +108,9 @@ public class DVAEnterYourDetailsExactlyPageObject extends DrivingLicencePageObje
 
     @FindBy(id = "dvaLicenceNumber-error")
     public WebElement drivingLicenceNumberErrorDVA;
+
+    @FindBy(id = "consentDVACheckbox-error")
+    public WebElement DVAConsentCheckboxError;
 
     // ------------------------
 
@@ -311,5 +319,14 @@ public class DVAEnterYourDetailsExactlyPageObject extends DrivingLicencePageObje
 
     private String mapErrorTextToSingleLine(WebElement webElement) {
         return webElement.getText().trim().replace("\n", "");
+    }
+
+    public void assertDVAConsentErrorInErrorSummary(String expectedText) {
+        Assert.assertEquals(expectedText, DVAConsentErrorInSummary.getText());
+    }
+
+    public void assertDVAConsentErrorOnCheckbox(String expectedText) {
+        Assert.assertEquals(
+                expectedText, DVAConsentCheckboxError.getText().trim().replace("\n", ""));
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -239,6 +239,11 @@ public class DrivingLicencePageObject extends UniversalSteps {
                     "//*[@class='govuk-error-summary error-summary']//*[@class='govuk-error-summary__body']//*[@class='govuk-list govuk-error-summary__list']//*[contains(@href,'#postcode')]")
     public WebElement InvalidPostcodeErrorInSummary;
 
+    @FindBy(
+            xpath =
+                    "//*[@class='govuk-error-summary error-summary']//*[@class='govuk-error-summary__body']//*[@class='govuk-list govuk-error-summary__list']//*[contains(@href,'#consentCheckbox')]")
+    public WebElement DVLAConsentErrorInSummary;
+
     // -------------------------
 
     // Field errors
@@ -269,6 +274,9 @@ public class DrivingLicencePageObject extends UniversalSteps {
 
     @FindBy(id = "postcode-error")
     public WebElement InvalidPostcodeFieldError;
+
+    @FindBy(id = "consentCheckbox-error")
+    public WebElement DVLAConsentCheckboxError;
 
     // ------------------------
 
@@ -979,5 +987,14 @@ public class DrivingLicencePageObject extends UniversalSteps {
 
     private WebElement getLabel(WebElement webElement) {
         return webElement.findElement(By.tagName("label"));
+    }
+
+    public void assertDVLAConsentErrorInErrorSummary(String expectedText) {
+        Assert.assertEquals(expectedText, DVLAConsentErrorInSummary.getText());
+    }
+
+    public void assertDVLAConsentErrorOnCheckbox(String expectedText) {
+        Assert.assertEquals(
+                expectedText, DVLAConsentCheckboxError.getText().trim().replace("\n", ""));
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVAEnterYourDetailsExactlyStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVAEnterYourDetailsExactlyStepDefs.java
@@ -222,4 +222,19 @@ public class DVAEnterYourDetailsExactlyStepDefs extends DVAEnterYourDetailsExact
     public void userReInputsDataAsADrivingLicenceSubject(String drivingLicenceSubject) {
         userReEntersDataAsDVADrivingLicenceSubject(drivingLicenceSubject);
     }
+
+    @When("^DVA consent checkbox is unselected$")
+    public void dva_consent_checkbox_click() {
+        consentDVACheckbox.click();
+    }
+
+    @Then("^User can see the DVA consent error in summary as (.*)$")
+    public void shortDVAConsentErrorMessageIsDisplayed(String expectedText) {
+        assertDVAConsentErrorInErrorSummary(expectedText);
+    }
+
+    @Then("^User can see the DVA consent error on the checkbox as (.*)$")
+    public void shortDVAConsentCheckboxErrorMessageIsDisplayed(String expectedText) {
+        assertDVAConsentErrorOnCheckbox(expectedText);
+    }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
@@ -196,4 +196,19 @@ public class DVLAAndDVADrivingLicenceStepDefs extends DrivingLicencePageObject {
     public void errorInJsonResponse(String documentNumber) throws IOException {
         new DrivingLicencePageObject().assertDocumentNumberInVc(documentNumber);
     }
+
+    @When("^DVLA consent checkbox is unselected$")
+    public void dvla_consent_checkbox_click() {
+        consentDVLACheckbox.click();
+    }
+
+    @Then("^User can see the DVLA consent error in summary as (.*)$")
+    public void shortDVLAConsentErrorMessageIsDisplayed(String expectedText) {
+        assertDVLAConsentErrorInErrorSummary(expectedText);
+    }
+
+    @Then("^User can see the DVLA consent error on the checkbox as (.*)$")
+    public void shortDVLAConsentCheckboxErrorMessageIsDisplayed(String expectedText) {
+        assertDVLAConsentErrorOnCheckbox(expectedText);
+    }
 }

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
@@ -508,3 +508,15 @@ Feature: DVA Driving Licence Test
     Examples:
       |DVADrivingLicenceSubject           |
       | IncorrectDrivingLicenceNumber     |
+
+  @DVADrivingLicence_test @build @staging @integration @smoke
+  Scenario Outline:  DVA Driving Licence error validation when DVA consent checkbox is unselected
+    Given User enters DVA data as a <DrivingLicenceSubject>
+    And DVA consent checkbox is unselected
+    When User clicks on continue
+    Then User can see the DVA consent error in summary as You must give your consent to continue
+    And User can see the DVA consent error on the checkbox as Error:You must give your consent to continue
+    And The test is complete and I close the driver
+    Examples:
+      |DrivingLicenceSubject             |
+      |DVADrivingLicenceSubjectHappyBilly|

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -595,3 +595,15 @@ Feature: Driving Licence Test
     Examples:
       |DrivingLicenceSubject             |
       | IncorrectDrivingLicenceNumber    |
+
+  @DVLADrivingLicence_test @build @staging @integration @smoke
+  Scenario Outline:  DVLA Driving Licence error validation when DVLA consent checkbox is unselected
+    Given User enters DVLA data as a <DrivingLicenceSubject>
+    And DVLA consent checkbox is unselected
+    When User clicks on continue
+    Then User can see the DVLA consent error in summary as You must give your consent to continue
+    And User can see the DVLA consent error on the checkbox as Error:You must give your consent to continue
+    And The test is complete and I close the driver
+    Examples:
+      |DrivingLicenceSubject             |
+      |DrivingLicenceSubjectHappyPeter   |

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/WelshLangDrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/WelshLangDrivingLicence.feature
@@ -407,3 +407,29 @@ Feature: Driving License Language Test
     And User clicks on continue
     Then I check the page title is Gwall: Rhowch eich manylion yn union fel maent yn ymddangos ar eich trwydded yrru – – GOV.UK
     And The test is complete and I close the driver
+
+  @Language-regression
+  Scenario Outline:  DVLA Driving Licence error validation when DVLA consent checkbox is unselected
+    Given I click on DVLA radio button and Parhau
+    Then User enters DVLA data as a <DrivingLicenceSubject>
+    And DVLA consent checkbox is unselected
+    When User clicks on continue
+    Then User can see the DVLA consent error in summary as Mae'n rhaid i chi roi eich caniatâd i barhau
+    And User can see the DVLA consent error on the checkbox as Gwall:Mae'n rhaid i chi roi eich caniatâd i barhau
+    And The test is complete and I close the driver
+    Examples:
+      |DrivingLicenceSubject             |
+      |DrivingLicenceSubjectHappyPeter   |
+
+  @Language-regression
+  Scenario Outline:  DVA Driving Licence error validation when DVA consent checkbox is unselected
+    Given I click on DVA radio button and Parhau
+    Then User enters DVA data as a <DrivingLicenceSubject>
+    And DVA consent checkbox is unselected
+    When User clicks on continue
+    Then User can see the DVA consent error in summary as Mae'n rhaid i chi roi eich caniatâd i barhau
+    And User can see the DVA consent error on the checkbox as Gwall:Mae'n rhaid i chi roi eich caniatâd i barhau
+    And The test is complete and I close the driver
+    Examples:
+      |DrivingLicenceSubject             |
+      |DVADrivingLicenceSubjectHappyBilly|


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
This consists of the test changes done for LIME-520 'Ask users for their consent before DVLA check their driving licence details' and LIME-568 'Ask users for their consent before DVA check their driving licence details'.
Automation tests have been updated to now include the DVLA and DVA Consent check box. Tests have also been added to validate the Consent error message in the error Summary as well as on the checkbox. Welsh translation tests have also been updated. 

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks