### PR TITLE
LIME-567: Enabling VC expiry removal in prod

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -123,7 +123,7 @@ Mappings:
       build: "true"
       staging: "true"
       integration: "true"
-      production: "false"
+      production: "true"
 
   JwtTtlUnitMapping:
     Environment:


### PR DESCRIPTION
## Proposed changes

### What changed

Enabling VC expiry removal in production

### Why did it change

So that IPV core and spot have more control on VC expiry

