### PR TITLE
LIME-663 Add DrivingLicenceLambdaInvocationDeviation alarm

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -653,7 +653,7 @@ Resources:
   CommonAPISessionLambdaConcurrencyThresholdReached:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: !Sub Driving Permit CRI ${Environment} - Common API Session Lambda concurrency threshold reached
+      AlarmDescription: !Sub Driving Licence ${Environment} - Common API Session Lambda concurrency threshold reached
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlarmTopicDL
@@ -676,7 +676,7 @@ Resources:
   CommonAPIAuthorizationLambdaConcurrencyThresholdReached:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: !Sub Driving Permit CRI ${Environment} - Common API Authorization Lambda concurrency threshold reached
+      AlarmDescription: !Sub Driving Licence ${Environment} - Common API Authorization Lambda concurrency threshold reached
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlarmTopicDL
@@ -699,7 +699,7 @@ Resources:
   CommonAPIAccessTokenLambdaConcurrencyThresholdReached:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: !Sub Driving Permit CRI ${Environment} - Common API AccessToken Lambda concurrency threshold reached
+      AlarmDescription: !Sub Driving Licence ${Environment} - Common API AccessToken Lambda concurrency threshold reached
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlarmTopicDL
@@ -724,7 +724,7 @@ Resources:
   DLDrivingPermitCheckLambdaConcurrencyThresholdReached:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: !Sub Driving Permit CRI ${Environment} - DrivingPermitCheck Lambda concurrency threshold reached
+      AlarmDescription: !Sub Driving Licence ${Environment} - DrivingPermitCheck Lambda concurrency threshold reached
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlarmTopicDL
@@ -747,7 +747,7 @@ Resources:
   DLIssueCredentialLambdaConcurrencyThresholdReached:
     Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmDescription: !Sub Driving Permit CRI ${Environment} - IssueCredential Lambda concurrency threshold reached
+      AlarmDescription: !Sub Driving Licence ${Environment} - IssueCredential Lambda concurrency threshold reached
       ActionsEnabled: true
       AlarmActions:
         - !Ref AlarmTopicDL
@@ -873,6 +873,49 @@ Resources:
               Dimensions:
                 - Name: ApiName
                   Value: !Sub "${AWS::StackName}-PrivateDLApi"
+            Period: 300
+            Stat: Sum
+
+  DrivingLicenceLambdaInvocationDeviation:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: !Sub Driving Licence ${Environment} Deviation between the session and issue credential lambda
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlarmTopicDL
+      OKActions:
+        - !Ref AlarmTopicDL
+      InsufficientDataActions: [ ]
+      DatapointsToAlarm: 10
+      EvaluationPeriods: 10
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: booleanDevationMetric
+          Label: BooleanDevationMetric
+          ReturnData: true
+          Expression: IF(ABS(((sessionInvocations-issueCredentialInvocations)/sessionInvocations) *100) > 50, 2, 1)
+        - Id: issueCredentialInvocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Invocations
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Ref IssueCredentialFunction
+            Period: 300
+            Stat: Sum
+        - Id: sessionInvocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/Lambda
+              MetricName: Invocations
+              Dimensions:
+                - Name: FunctionName
+                  Value: !Sub "${CommonStackName}-SessionFunction"
             Period: 300
             Stat: Sum
 


### PR DESCRIPTION
## Proposed changes

### What changed

Add DrivingLicenceLambdaInvocationDeviation alarm
Align AlarmDescriptions to use "Driving Licence"

### Why did it change

DrivingLicenceLambdaInvocationDeviation to alert if the number of sessionInvocations is exceeding the number of issueCredentialInvocations by 50%

Fix inconsistency in CRI name for AlarmDescriptions

### Issue tracking

- [LIME-663](https://govukverify.atlassian.net/browse/LIME-663)


[LIME-663]: https://govukverify.atlassian.net/browse/LIME-663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ