### PR TITLE
Expiry Date should not be present in the VC test

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -25,8 +25,7 @@ import java.util.stream.Collectors;
 import static gov.di_ipv_drivingpermit.pages.Headers.IPV_CORE_STUB;
 import static gov.di_ipv_drivingpermit.utilities.BrowserUtils.checkOkHttpResponseOnLink;
 import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DrivingLicencePageObject extends UniversalSteps {
 
@@ -1094,5 +1093,22 @@ public class DrivingLicencePageObject extends UniversalSteps {
 
     public void assertDVLAContentLineTwo(String contentDVLALine2) {
         Assert.assertEquals(contentDVLALine2, dvlaSentenceTwo.getText());
+    }
+
+    private JsonNode getVCFromJson(String vc) throws JsonProcessingException {
+        String result = JSONPayload.getText();
+        LOGGER.info("result = " + result);
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(result);
+        return jsonNode.get(vc);
+    }
+
+    public void expiryAbsentFromVC(String checkType) throws JsonProcessingException {
+        JsonNode vcNode = getVCFromJson("vc");
+        JsonNode evidenceNode = vcNode.get("evidence").get(0);
+        boolean expInVC =
+                evidenceNode.findValues("expiryDate").stream()
+                        .anyMatch(x -> x.asText().equals(checkType));
+        assertFalse(expInVC);
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -1124,12 +1124,12 @@ public class DrivingLicencePageObject extends UniversalSteps {
                 LocalDateTime.ofEpochSecond(Long.parseLong(nbf), 0, ZoneOffset.UTC);
 
         assertNull(expNode);
-        assertFalse(isWithinRange(nbfDateTime));
+        assertTrue(isWithinRange(nbfDateTime));
     }
 
     boolean isWithinRange(LocalDateTime testDate) {
-        LocalDateTime nbfMin = LocalDateTime.now().minusSeconds(30);
-        LocalDateTime nbfMax = LocalDateTime.now().plusSeconds(30);
+        LocalDateTime nbfMin = LocalDateTime.now(ZoneOffset.UTC).minusSeconds(30);
+        LocalDateTime nbfMax = LocalDateTime.now(ZoneOffset.UTC).plusSeconds(30);
         LOGGER.info("nbfMin " + nbfMin);
         LOGGER.info("nbfMax " + nbfMax);
         LOGGER.info("nbf " + testDate);

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
@@ -1,5 +1,6 @@
 package gov.di_ipv_drivingpermit.step_definitions;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import gov.di_ipv_drivingpermit.pages.*;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
@@ -258,5 +259,11 @@ public class DVLAAndDVADrivingLicenceStepDefs extends DrivingLicencePageObject {
     public void iSeeTheLineToFindOutMoreAboutHowYourDrivingLicenceDetailsWillBeUsedYouCanRead(
             String contentDVLALine2) {
         assertDVLAContentLineTwo(contentDVLALine2);
+    }
+
+    @And("^(.*) should not be absent in the JSON payload")
+    public void expiryDateShouldNotBeAbsentInTheJSONPayload(String checkType)
+            throws JsonProcessingException {
+        expiryAbsentFromVC(checkType);
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/DVLAAndDVADrivingLicenceStepDefs.java
@@ -261,9 +261,8 @@ public class DVLAAndDVADrivingLicenceStepDefs extends DrivingLicencePageObject {
         assertDVLAContentLineTwo(contentDVLALine2);
     }
 
-    @And("^(.*) should not be absent in the JSON payload")
-    public void expiryDateShouldNotBeAbsentInTheJSONPayload(String checkType)
-            throws JsonProcessingException {
-        expiryAbsentFromVC(checkType);
+    @And("^(.*) should not be present in the JSON payload$")
+    public void nbfAndExpiryInJsonResponse(String exp) throws JsonProcessingException {
+        expiryAbsentFromVC(exp);
     }
 }

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DLProveYourIdentityFullJourneyRoute.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DLProveYourIdentityFullJourneyRoute.feature
@@ -35,8 +35,10 @@ Feature: Prove Your Identity Full Journey
   @dlProveYourIdentityFullJourney
   Scenario Outline: DVA Driving Licence Prove Your Identity Full Journey Route Happy Path (STUB)
     And I select the radio option UK driving licence and click on Continue
+    And I should be on `Who was your UK driving licence issued by? – Prove your identity – GOV.UK` page
     And I should be on `Who was your UK driving licence issued by` page
     And I click on DVA radio button and Continue
+    And I should be on DVA `Enter your details exactly as they appear on your UK driving licence - Prove your identity - GOV.UK` page
     And I should be on DVA `Enter your details exactly as they appear on your UK driving licence` page
     When User enters DVA data as a <DVADrivingLicenceSubject>
     And User clicks on continue
@@ -120,6 +122,7 @@ Feature: Prove Your Identity Full Journey
     Given I select the radio option UK driving licence and click on Continue
     And I should be on `Who was your UK driving licence issued by` page
     And I click on DVLA radio button and Continue
+    And I should be on `Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK` page
     And I should be on `Enter your details exactly as they appear on your UK driving licence` page
     When User enters DVLA data as a <DrivingLicenceSubject>
     And User clicks on continue

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
@@ -15,6 +15,7 @@ Feature: DVA Driving Licence Test
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2 and strength score 3
     And JSON response should contain personal number 55667788 same as given Driving Licence
+    And Expiry date should not be absent in the JSON payload
     And The test is complete and I close the driver
     Examples:
       |DVADrivingLicenceSubject             |

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
@@ -15,7 +15,7 @@ Feature: DVA Driving Licence Test
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2 and strength score 3
     And JSON response should contain personal number 55667788 same as given Driving Licence
-    And Expiry date should not be absent in the JSON payload
+    And exp should not be present in the JSON payload
     And The test is complete and I close the driver
     Examples:
       |DVADrivingLicenceSubject             |

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -15,6 +15,7 @@ Feature: Driving Licence Test
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2 and strength score 3
     And JSON response should contain personal number PARKE610112PBFGH same as given Driving Licence
+    And Expiry date should not be absent in the JSON payload
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject             |

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -15,7 +15,7 @@ Feature: Driving Licence Test
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2 and strength score 3
     And JSON response should contain personal number PARKE610112PBFGH same as given Driving Licence
-    And Expiry date should not be absent in the JSON payload
+    And exp should not be present in the JSON payload
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject             |


### PR DESCRIPTION
Remove the existing test step where we validate the expiry date as 6 months from the current date
Add a new test step to validate that the exp date field is no longer available in the VCs in DL CRI

(https://govukverify.atlassian.net/browse/LIME-670)