### PR TITLE
LIME-682 - Refactoring Service factory WIP

### DIFF
--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
@@ -30,9 +30,10 @@ import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DocumentCheckVerificationResult;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DocumentVerificationResponse;
 import uk.gov.di.ipv.cri.drivingpermit.api.exception.OAuthHttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.cri.drivingpermit.api.service.CRIServiceFactory;
+import uk.gov.di.ipv.cri.drivingpermit.api.service.CommonServiceFactory;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.ConfigurationService;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.IdentityVerificationService;
-import uk.gov.di.ipv.cri.drivingpermit.api.service.ServiceFactory;
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.CheckDetails;
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.DrivingPermitForm;
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.IssuingAuthority;
@@ -76,38 +77,36 @@ public class DrivingPermitHandler
             throws NoSuchAlgorithmException, InvalidKeyException, CertificateException,
                     InvalidKeySpecException, HttpException, KeyStoreException, IOException {
         this.objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
-        ServiceFactory serviceFactory = new ServiceFactory(objectMapper);
-        this.eventProbe = new EventProbe();
-        this.identityVerificationService = serviceFactory.getIdentityVerificationService();
+        CommonServiceFactory commonServiceFactory = new CommonServiceFactory(objectMapper);
+        CRIServiceFactory criServiceFactory = new CRIServiceFactory(commonServiceFactory);
+        this.eventProbe = commonServiceFactory.getEventProbe();
+        this.identityVerificationService = criServiceFactory.getIdentityVerificationService();
         this.personIdentityService = new PersonIdentityService();
         this.sessionService = new SessionService();
-        this.configurationService = serviceFactory.getConfigurationService();
+        this.configurationService = commonServiceFactory.getConfigurationService();
         this.dataStore =
                 new DataStore<>(
                         configurationService.getDocumentCheckResultTableName(),
                         DocumentCheckResultItem.class,
                         DataStore.getClient());
-        this.auditService = serviceFactory.getAuditService();
+        this.auditService = commonServiceFactory.getAuditService();
     }
 
     @ExcludeFromGeneratedCoverageReport
     public DrivingPermitHandler(
-            ServiceFactory serviceFactory,
-            ObjectMapper objectMapper,
-            EventProbe eventProbe,
+            CommonServiceFactory commonServiceFactory,
+            CRIServiceFactory criServiceFactory,
             PersonIdentityService personIdentityService,
             SessionService sessionService,
-            DataStore<DocumentCheckResultItem> dataStore,
-            ConfigurationService configurationService,
-            AuditService auditService) {
-        this.identityVerificationService = serviceFactory.getIdentityVerificationService();
-        this.objectMapper = objectMapper;
-        this.eventProbe = eventProbe;
+            DataStore<DocumentCheckResultItem> dataStore) {
+        this.identityVerificationService = criServiceFactory.getIdentityVerificationService();
+        this.objectMapper = commonServiceFactory.getObjectMapper();
+        this.eventProbe = commonServiceFactory.getEventProbe();
         this.personIdentityService = personIdentityService;
         this.sessionService = sessionService;
-        this.configurationService = configurationService;
+        this.configurationService = commonServiceFactory.getConfigurationService();
         this.dataStore = dataStore;
-        this.auditService = auditService;
+        this.auditService = commonServiceFactory.getAuditService();
     }
 
     @Override

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/CRIServiceFactory.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/CRIServiceFactory.java
@@ -1,0 +1,81 @@
+package uk.gov.di.ipv.cri.drivingpermit.api.service;
+
+import org.apache.http.HttpException;
+import software.amazon.awssdk.regions.Region;
+import uk.gov.di.ipv.cri.common.library.annotations.ExcludeFromGeneratedCoverageReport;
+import uk.gov.di.ipv.cri.drivingpermit.api.gateway.ThirdPartyDocumentGateway;
+
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
+
+public class CRIServiceFactory {
+    private final CommonServiceFactory commonServiceFactory;
+    private final IdentityVerificationService identityVerificationService;
+    private final ContraindicationMapper contraindicationMapper;
+    private final DcsCryptographyService dcsCryptographyService;
+    private final FormDataValidator formDataValidator;
+    private final Region awsRegion = Region.of(System.getenv("AWS_REGION"));
+
+    public CRIServiceFactory(CommonServiceFactory commonServiceFactory)
+            throws NoSuchAlgorithmException, InvalidKeyException, CertificateException,
+                    InvalidKeySpecException, KeyStoreException, IOException, HttpException {
+        this.commonServiceFactory = commonServiceFactory;
+        this.formDataValidator = new FormDataValidator();
+        this.dcsCryptographyService =
+                new DcsCryptographyService(commonServiceFactory.getConfigurationService());
+        this.contraindicationMapper =
+                new ContraIndicatorRemoteMapper(commonServiceFactory.getConfigurationService());
+        this.identityVerificationService = createIdentityVerificationService(commonServiceFactory);
+    }
+
+    /** Creates services used by this CRI */
+    @ExcludeFromGeneratedCoverageReport
+    CRIServiceFactory(
+            CommonServiceFactory commonServiceFactory,
+            DcsCryptographyService dcsCryptographyService,
+            ContraindicationMapper contraindicationMapper,
+            FormDataValidator formDataValidator)
+            throws NoSuchAlgorithmException, InvalidKeyException, CertificateException,
+                    InvalidKeySpecException {
+        this.commonServiceFactory = commonServiceFactory;
+        this.dcsCryptographyService = dcsCryptographyService;
+        this.contraindicationMapper = contraindicationMapper;
+        this.formDataValidator = formDataValidator;
+        this.identityVerificationService = createIdentityVerificationService(commonServiceFactory);
+    }
+
+    private IdentityVerificationService createIdentityVerificationService(
+            CommonServiceFactory commonServiceFactory) {
+
+        ThirdPartyDocumentGateway thirdPartyGateway =
+                new ThirdPartyDocumentGateway(
+                        commonServiceFactory.getObjectMapper(),
+                        this.dcsCryptographyService,
+                        commonServiceFactory.getConfigurationService(),
+                        commonServiceFactory.getHttpRetryer(),
+                        commonServiceFactory.getEventProbe());
+
+        return new IdentityVerificationService(
+                thirdPartyGateway,
+                this.formDataValidator,
+                this.contraindicationMapper,
+                commonServiceFactory.getAuditService(),
+                commonServiceFactory.getConfigurationService(),
+                commonServiceFactory.getObjectMapper(),
+                commonServiceFactory.getEventProbe());
+    }
+
+    private static final char[] password = "password".toCharArray();
+
+    public IdentityVerificationService getIdentityVerificationService() {
+        return this.identityVerificationService;
+    }
+
+    public ContraindicationMapper getContraindicationMapper() {
+        return contraindicationMapper;
+    }
+}

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
@@ -14,6 +14,7 @@ import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.sqs.SqsClient;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventContext;
 import uk.gov.di.ipv.cri.common.library.domain.AuditEventType;
 import uk.gov.di.ipv.cri.common.library.exception.SqsException;
@@ -25,9 +26,10 @@ import uk.gov.di.ipv.cri.common.library.service.SessionService;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DocumentCheckVerificationResult;
 import uk.gov.di.ipv.cri.drivingpermit.api.exception.OAuthHttpResponseExceptionWithErrorBody;
+import uk.gov.di.ipv.cri.drivingpermit.api.service.CRIServiceFactory;
+import uk.gov.di.ipv.cri.drivingpermit.api.service.CommonServiceFactory;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.ConfigurationService;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.IdentityVerificationService;
-import uk.gov.di.ipv.cri.drivingpermit.api.service.ServiceFactory;
 import uk.gov.di.ipv.cri.drivingpermit.api.testdata.DocumentCheckVerificationResultDataGenerator;
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.DrivingPermitForm;
 import uk.gov.di.ipv.cri.drivingpermit.library.persistence.item.DocumentCheckResultItem;
@@ -54,7 +56,8 @@ import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.LAMBDA
 
 @ExtendWith(MockitoExtension.class)
 class DrivingPermitHandlerTest {
-    @Mock private ServiceFactory mockServiceFactory;
+    @Mock private CommonServiceFactory mockCommonServiceFactory;
+    @Mock private CRIServiceFactory mockCRIServiceFactory;
     @Mock private ObjectMapper mockObjectMapper;
     @Mock private IdentityVerificationService mockIdentityVerificationService;
     @Mock private EventProbe mockEventProbe;
@@ -64,22 +67,20 @@ class DrivingPermitHandlerTest {
     @Mock private DataStore dataStore;
     @Mock private ConfigurationService configurationService;
     @Mock private AuditService auditService;
+    @Mock private SqsClient sqsClient;
     private DrivingPermitHandler drivingPermitHandler;
 
     @BeforeEach
     void setup() {
-        when(mockServiceFactory.getIdentityVerificationService())
+        when(mockCRIServiceFactory.getIdentityVerificationService())
                 .thenReturn(mockIdentityVerificationService);
         this.drivingPermitHandler =
                 new DrivingPermitHandler(
-                        mockServiceFactory,
-                        mockObjectMapper,
-                        mockEventProbe,
+                        mockCommonServiceFactory,
+                        mockCRIServiceFactory,
                         personIdentityService,
                         mockSessionService,
-                        dataStore,
-                        configurationService,
-                        auditService);
+                        dataStore);
     }
 
     @Test
@@ -124,6 +125,9 @@ class DrivingPermitHandlerTest {
         when(context.getFunctionName()).thenReturn("functionName");
         when(context.getFunctionVersion()).thenReturn("1.0");
         when(configurationService.getDocumentCheckItemExpirationEpoch()).thenReturn(1000L);
+
+        when(mockCommonServiceFactory.getEventProbe()).thenReturn(new EventProbe());
+        when(mockCommonServiceFactory.getAuditService()).thenReturn(auditService);
 
         APIGatewayProxyResponseEvent responseEvent =
                 drivingPermitHandler.handleRequest(mockRequestEvent, context);
@@ -180,6 +184,9 @@ class DrivingPermitHandlerTest {
 
         when(context.getFunctionName()).thenReturn("functionName");
         when(context.getFunctionVersion()).thenReturn("1.0");
+        when(mockCommonServiceFactory.getEventProbe()).thenReturn(new EventProbe());
+        when(mockCommonServiceFactory.getAuditService()).thenReturn(auditService);
+
         APIGatewayProxyResponseEvent responseEvent =
                 drivingPermitHandler.handleRequest(mockRequestEvent, context);
 
@@ -243,6 +250,8 @@ class DrivingPermitHandlerTest {
 
         when(context.getFunctionName()).thenReturn("functionName");
         when(context.getFunctionVersion()).thenReturn("1.0");
+        when(mockCommonServiceFactory.getEventProbe()).thenReturn(new EventProbe());
+        when(mockCommonServiceFactory.getAuditService()).thenReturn(auditService);
         APIGatewayProxyResponseEvent responseEvent =
                 drivingPermitHandler.handleRequest(mockRequestEvent, context);
 
@@ -285,6 +294,8 @@ class DrivingPermitHandlerTest {
 
         when(context.getFunctionName()).thenReturn("functionName");
         when(context.getFunctionVersion()).thenReturn("1.0");
+        when(mockCommonServiceFactory.getEventProbe()).thenReturn(new EventProbe());
+        when(mockCommonServiceFactory.getAuditService()).thenReturn(auditService);
         APIGatewayProxyResponseEvent responseEvent =
                 drivingPermitHandler.handleRequest(mockRequestEvent, context);
 
@@ -336,6 +347,8 @@ class DrivingPermitHandlerTest {
 
         when(context.getFunctionName()).thenReturn("functionName");
         when(context.getFunctionVersion()).thenReturn("1.0");
+        when(mockCommonServiceFactory.getEventProbe()).thenReturn(new EventProbe());
+        when(mockCommonServiceFactory.getAuditService()).thenReturn(auditService);
 
         APIGatewayProxyResponseEvent responseEvent =
                 drivingPermitHandler.handleRequest(mockRequestEvent, context);

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/CRIServiceFactoryTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/CRIServiceFactoryTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.ipv.cri.drivingpermit.api.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpException;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,14 +14,19 @@ import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
+import java.io.IOException;
 import java.security.InvalidKeyException;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SystemStubsExtension.class)
-class ServiceFactoryTest {
+class CRIServiceFactoryTest {
+    @Mock private CommonServiceFactory mockCommonServiceFactory;
     @Mock private ObjectMapper mockObjectMapper;
     @Mock private ConfigurationService mockConfigurationService;
     @Mock private ContraindicationMapper mockContraindicationMapper;
@@ -37,23 +43,15 @@ class ServiceFactoryTest {
 
     @Test
     void shouldCreateIdentityVerificationService()
-            throws NoSuchAlgorithmException, InvalidKeyException {
+            throws NoSuchAlgorithmException, InvalidKeyException, CertificateException,
+                    InvalidKeySpecException, HttpException, KeyStoreException, IOException {
         environmentVariables.set("AWS_REGION", "eu-west-2");
+        CommonServiceFactory commonServiceFactory = new CommonServiceFactory(mockObjectMapper);
 
-        ServiceFactory serviceFactory =
-                new ServiceFactory(
-                        mockObjectMapper,
-                        mockEventProbe,
-                        mockConfigurationService,
-                        mockDcsCryptographyService,
-                        mockContraindicationMapper,
-                        mockFormDataValidator,
-                        mockHttpClient,
-                        mockAuditService,
-                        mockHttpRetryer);
+        CRIServiceFactory CRIServiceFactory = new CRIServiceFactory(commonServiceFactory);
 
         IdentityVerificationService identityVerificationService =
-                serviceFactory.getIdentityVerificationService();
+                CRIServiceFactory.getIdentityVerificationService();
 
         assertNotNull(identityVerificationService);
     }

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/CommonServiceFactoryTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/CommonServiceFactoryTest.java
@@ -1,0 +1,41 @@
+package uk.gov.di.ipv.cri.drivingpermit.api.service;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+@ExtendWith(MockitoExtension.class)
+@ExtendWith(SystemStubsExtension.class)
+class CommonServiceFactoryTest {
+    /*
+    @Mock private ObjectMapper mockObjectMapper;
+    @Mock private ConfigurationService mockConfigurationService;
+    @Mock private ContraindicationMapper mockContraindicationMapper;
+    @Mock private FormDataValidator mockFormDataValidator;
+    @Mock private CloseableHttpClient mockHttpClient;
+    @Mock private DcsCryptographyService mockDcsCryptographyService;
+    @Mock private HttpRetryer mockHttpRetryer;
+
+    @Mock private AuditService mockAuditService;
+
+    @Mock private EventProbe mockEventProbe;
+
+    @SystemStub private EnvironmentVariables environmentVariables;
+
+    @Test
+    void shouldCreateIdentityVerificationService()
+            throws NoSuchAlgorithmException, InvalidKeyException, CertificateException,
+                    InvalidKeySpecException {
+        environmentVariables.set("AWS_REGION", "eu-west-2");
+
+        CRIServiceFactory CRIServiceFactory =
+                new CRIServiceFactory();
+
+        IdentityVerificationService identityVerificationService =
+                CRIServiceFactory.getIdentityVerificationService();
+
+        assertNotNull(identityVerificationService);
+    }
+
+     */
+}


### PR DESCRIPTION
### What changed

Forked Service factory so that one service factory is used to provide common Services used across CRIs, and another is used for services specific to the driving licence CRI. This means that there is one service factory for issueCredential lambda (which uses all common services) and another service factory used for loading in CRI specific services (such as those used in the drivingPermitCheck lambda)

### Why did it change
To keep inline with best coding practices (under 8 parameters per constructor) and to improve readability of code, this creates a clearer separation of services used for issueCredential and services used for drivingPermitCheck lambdas, meaning only services that are necessary to each lambda are loaded in

DevNote:

Need to fix mocks for tests before merge 