### PR TITLE
LIME-723 Correct CI returned when document data is invalid

### DIFF
--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
@@ -39,7 +39,7 @@ Feature: DVA Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And JSON response should contain personal number 88776655 same as given Driving Licence
     And The test is complete and I close the driver
     Examples:
@@ -53,7 +53,7 @@ Feature: DVA Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DVADrivingLicenceSubject |
@@ -66,7 +66,7 @@ Feature: DVA Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DVADrivingLicenceSubject |
@@ -79,7 +79,7 @@ Feature: DVA Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DVADrivingLicenceSubject |
@@ -92,7 +92,7 @@ Feature: DVA Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DVADrivingLicenceSubject |
@@ -105,7 +105,7 @@ Feature: DVA Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DVADrivingLicenceSubject |
@@ -118,7 +118,7 @@ Feature: DVA Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DVADrivingLicenceSubject |
@@ -147,7 +147,7 @@ Feature: DVA Driving Licence Test
     When User Re-enters DVA data as a <DVADrivingLicenceSubject>
     And User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DVADrivingLicenceSubject |
@@ -160,7 +160,7 @@ Feature: DVA Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User click on ‘prove your identity another way' Link
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
 
   @DVADrivingLicence_test @smoke

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -28,7 +28,7 @@ Feature: Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And JSON response should contain personal number PARKE610112PBFGI same as given Driving Licence
     And The test is complete and I close the driver
     Examples:
@@ -64,7 +64,7 @@ Feature: Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject |
@@ -77,7 +77,7 @@ Feature: Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject      |
@@ -90,7 +90,7 @@ Feature: Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject |
@@ -103,7 +103,7 @@ Feature: Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject |
@@ -116,7 +116,7 @@ Feature: Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject |
@@ -129,7 +129,7 @@ Feature: Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject |
@@ -157,7 +157,7 @@ Feature: Driving Licence Test
     When User Re-enters DVLA data as a <DrivingLicenceSubject>
     And User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject |
@@ -170,7 +170,7 @@ Feature: Driving Licence Test
     Then Proper error message for Could not find your details is displayed
     When User click on ‘prove your identity another way' Link
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
-    And JSON payload should contain ci DO2, validity score 0 and strength score 3
+    And JSON payload should contain ci D02, validity score 0 and strength score 3
     And The test is complete and I close the driver
 
   @DVLADrivingLicence_test @smoke

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/IdentityVerificationService.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/IdentityVerificationService.java
@@ -24,17 +24,21 @@ import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.FORM_D
 
 public class IdentityVerificationService {
     private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final String DOCUMENT_VALIDITY_CI = "D02";
+
+    private static final int MAX_DRIVING_PERMIT_GPG45_STRENGTH_VALUE = 3;
+    private static final int MAX_DRIVING_PERMIT_GPG45_VALIDITY_VALUE = 2;
+    private static final int MIN_DRIVING_PERMIT_GPG45_VALUE = 0;
+    private static final int MAX_DRIVING_ACTIVITY_HISTORY_SCORE = 1;
+    private static final int MIN_DRIVING_ACTIVITY_HISTORY_SCORE = 0;
+
     private static final String ERROR_MSG_CONTEXT =
             "Error occurred when attempting to invoke the third party api";
     private static final String ERROR_DRIVING_PERMIT_CHECK_RESULT_RETURN_NULL =
             "Null DrivingPermitCheckResult returned when invoking third party API.";
     private static final String ERROR_DRIVING_PERMIT_CHECK_RESULT_NO_ERR_MSG =
             "DrivingPermitCheckResult had no error message.";
-    private static final int MAX_DRIVING_PERMIT_GPG45_STRENGTH_VALUE = 3;
-    private static final int MAX_DRIVING_PERMIT_GPG45_VALIDITY_VALUE = 2;
-    private static final int MIN_DRIVING_PERMIT_GPG45_VALUE = 0;
-    private static final int MAX_DRIVING_ACTIVITY_HISTORY_SCORE = 1;
-    private static final int MIN_DRIVING_ACTIVITY_HISTORY_SCORE = 0;
 
     private final FormDataValidator formDataValidator;
     private final ThirdPartyDocumentGateway thirdPartyGateway;
@@ -160,6 +164,6 @@ public class IdentityVerificationService {
     }
 
     private List<String> calculateContraIndicators(DocumentCheckResult documentCheckResult) {
-        return documentCheckResult.isValid() ? null : List.of("DO2");
+        return documentCheckResult.isValid() ? null : List.of(DOCUMENT_VALIDITY_CI);
     }
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Correct the CI returned for checks that deem the document data to be not valid to `D02`

Amended acceptance test. 

### Why did it change

The CI was incorrectly set as `DO2` (Delta Oscar Two) vs the correct `D02` (Delta Zero Two)

Incorrect CI value was also present in the acceptance tests

### Issue tracking

- [LIME-723](https://govukverify.atlassian.net/browse/LIME-723)


[LIME-723]: https://govukverify.atlassian.net/browse/LIME-723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ