### PR TITLE
LIME-507 - Added `HEADER_DOCUMENT_CHECKING_ROUTE` header to split path between DCS and DVAD.

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -140,13 +140,13 @@ Mappings:
       integration: MONTHS
       production: MONTHS
 
-  useLegacyMapping:
+  dvaDirectEnabledMapping:
     Environment:
       dev: "true"
-      build: "true"
-      staging: "true"
-      integration: "true"
-      production: "true"
+      build: "false"
+      staging: "false"
+      integration: "false"
+      production: "false"
 
   DrivingPermitCriAudienceMapping:
     Environment:
@@ -395,7 +395,7 @@ Resources:
               Resource:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/contraindicationMappings"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
-                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/useLegacy"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/dvaDirectEnabled"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTtl"
@@ -646,12 +646,12 @@ Resources:
       Value: "false"
       Description: Feature toggle to allow logging of DCS responses
 
-  useLegacyParameter:
+  dvaDirectEnabledParameter:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub "/${AWS::StackName}/useLegacy"
+      Name: !Sub "/${AWS::StackName}/dvaDirectEnabled"
       Type: String
-      Value: !FindInMap [ useLegacyMapping, Environment, !Ref Environment ]
+      Value: !FindInMap [ dvaDirectEnabledMapping, Environment, !Ref Environment ]
       Description: Feature toggle to switch between dcs/dva direct
 
   LoggingKmsKey:

--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -143,8 +143,8 @@ Mappings:
   dvaDirectEnabledMapping:
     Environment:
       dev: "true"
-      build: "false"
-      staging: "false"
+      build: "true"
+      staging: "true"
       integration: "false"
       production: "false"
 

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
@@ -59,6 +59,7 @@ public class DrivingPermitHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOGGER = LogManager.getLogger();
+    private static final String HEADER_DOCUMENT_CHECKING_ROUTE = "document-checking-route";
 
     private ObjectMapper objectMapper;
     private EventProbe eventProbe;
@@ -152,7 +153,10 @@ public class DrivingPermitHandler
                                 .TOO_MANY_RETRY_ATTEMPTS);
             }
 
-            ThirdPartyAPIService thirdPartyAPIService = selectThirdPartyAPIService();
+            ThirdPartyAPIService thirdPartyAPIService =
+                    selectThirdPartyAPIService(
+                            configurationService.getDvaDirectEnabled(),
+                            headers.get(HEADER_DOCUMENT_CHECKING_ROUTE));
 
             LOGGER.info(
                     "Verifying document details using {}", thirdPartyAPIService.getServiceName());
@@ -320,14 +324,15 @@ public class DrivingPermitHandler
                 new FormDataValidator(), null, serviceFactory.getEventProbe());
     }
 
-    private ThirdPartyAPIService selectThirdPartyAPIService() {
+    private ThirdPartyAPIService selectThirdPartyAPIService(
+            boolean dvaDirectEnabled, String documentCheckingRouteHeader) {
         // TODO Change to a switch for each api and read feature flag + header
-        if (configurationService.getUseLegacy()) {
-            // Legacy DCS
-            return thirdPartyAPIServiceFactory.getDcsThirdPartyAPIService();
-        } else {
+        if (dvaDirectEnabled && "dva direct".equalsIgnoreCase(documentCheckingRouteHeader)) {
             // DVA
             return thirdPartyAPIServiceFactory.getDvaThirdPartyAPIService();
+        } else {
+            // Legacy DCS
+            return thirdPartyAPIServiceFactory.getDcsThirdPartyAPIService();
         }
     }
 }

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandler.java
@@ -327,7 +327,7 @@ public class DrivingPermitHandler
     private ThirdPartyAPIService selectThirdPartyAPIService(
             boolean dvaDirectEnabled, String documentCheckingRouteHeader) {
         // TODO Change to a switch for each api and read feature flag + header
-        if (dvaDirectEnabled && "dva direct".equalsIgnoreCase(documentCheckingRouteHeader)) {
+        if (dvaDirectEnabled && "dva-direct".equalsIgnoreCase(documentCheckingRouteHeader)) {
             // DVA
             return thirdPartyAPIServiceFactory.getDvaThirdPartyAPIService();
         } else {

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ConfigurationService.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ConfigurationService.java
@@ -58,7 +58,7 @@ public class ConfigurationService {
     private final String parameterPrefix;
     private final String commonParameterPrefix;
     private final String dvaEndpointUri;
-    private final boolean useLegacy;
+    private final boolean dvaDirectEnabled;
     private final Certificate dcsSigningCert;
     private final Certificate dcsEncryptionCert;
     private final Certificate drivingPermitTlsSelfCert;
@@ -158,7 +158,8 @@ public class ConfigurationService {
         this.dvaEndpointUri = paramProvider.get(getParameterName(DVA_ENDPOINT));
 
         // *****************************Feature Toggles*******************************
-        this.useLegacy = Boolean.parseBoolean(paramProvider.get(getParameterName("useLegacy")));
+        this.dvaDirectEnabled =
+                Boolean.parseBoolean(paramProvider.get(getParameterName("dvaDirectEnabled")));
         this.isPerformanceStub =
                 Boolean.parseBoolean(paramProvider.get(getParameterName("isPerformanceStub")));
         this.logDcsResponse =
@@ -290,8 +291,8 @@ public class ConfigurationService {
         return dvaTlsSelfCert;
     }
 
-    public boolean getUseLegacy() {
-        return useLegacy;
+    public boolean getDvaDirectEnabled() {
+        return dvaDirectEnabled;
     }
 
     public long getDocumentCheckItemExpirationEpoch() {

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dcs/DcsThirdPartyDocumentGateway.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dcs/DcsThirdPartyDocumentGateway.java
@@ -123,10 +123,10 @@ public class DcsThirdPartyDocumentGateway implements ThirdPartyAPIService {
         String drivingPermitDocumentNumber = drivingPermitData.getDrivingLicenceNumber();
         LocalDate drivingPermitIssueDate = drivingPermitData.getIssueDate();
 
-        String dcsEndpointUri = null;
+        String dcsEndpointUri = configurationService.getDcsEndpointUri();
         switch (issuingAuthority) {
             case DVA:
-                dcsEndpointUri = configurationService.getDcsEndpointUri() + "/dva-driving-licence";
+                dcsEndpointUri += "/dva-driving-licence";
 
                 dcsPayload.setExpiryDate(drivingPermitExpiryDate);
                 dcsPayload.setDriverNumber(drivingPermitDocumentNumber);
@@ -137,7 +137,7 @@ public class DcsThirdPartyDocumentGateway implements ThirdPartyAPIService {
                 dcsPayload.setDateOfIssue(drivingPermitIssueDate);
                 break;
             case DVLA:
-                dcsEndpointUri = configurationService.getDcsEndpointUri() + "/driving-licence";
+                dcsEndpointUri += "/driving-licence";
 
                 dcsPayload.setIssueNumber(drivingPermitData.getIssueNumber());
 
@@ -150,7 +150,7 @@ public class DcsThirdPartyDocumentGateway implements ThirdPartyAPIService {
                         HttpStatusCode.INTERNAL_SERVER_ERROR,
                         ErrorResponse.FAILED_TO_PARSE_DRIVING_PERMIT_FORM_DATA);
         }
-        JWSObject preparedDcsPayload = preparePayload(dcsPayload);
+        JWSObject preparedDcsPayload = prepareDcsPayload(dcsPayload);
 
         String requestBody = preparedDcsPayload.serialize();
 
@@ -180,7 +180,7 @@ public class DcsThirdPartyDocumentGateway implements ThirdPartyAPIService {
         return documentCheckResult;
     }
 
-    private JWSObject preparePayload(DcsPayload dcsPayload)
+    private JWSObject prepareDcsPayload(DcsPayload dcsPayload)
             throws OAuthHttpResponseExceptionWithErrorBody {
         LOGGER.info("Preparing payload for DCS");
         try {

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
@@ -30,6 +30,7 @@ import uk.gov.di.ipv.cri.drivingpermit.api.service.IdentityVerificationService;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.ServiceFactory;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.ThirdPartyAPIService;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.ThirdPartyAPIServiceFactory;
+import uk.gov.di.ipv.cri.drivingpermit.api.service.dcs.DcsThirdPartyDocumentGateway;
 import uk.gov.di.ipv.cri.drivingpermit.api.testdata.DocumentCheckVerificationResultDataGenerator;
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.DrivingPermitForm;
 import uk.gov.di.ipv.cri.drivingpermit.library.persistence.item.DocumentCheckResultItem;
@@ -56,6 +57,7 @@ import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.LAMBDA
 
 @ExtendWith(MockitoExtension.class)
 class DrivingPermitHandlerTest {
+    private static final String HEADER_DOCUMENT_CHECKING_ROUTE = "document-checking-route";
     @Mock private ObjectMapper mockObjectMapper;
     @Mock private EventProbe mockEventProbe;
     @Mock private SessionService mockSessionService;
@@ -67,7 +69,7 @@ class DrivingPermitHandlerTest {
 
     @Mock private ServiceFactory mockServiceFactory;
     @Mock ThirdPartyAPIServiceFactory mockThirdPartyAPIServiceFactory;
-    @Mock ThirdPartyAPIService mockDcsThirdPartyDocumentGateway;
+    @Mock DcsThirdPartyDocumentGateway mockDcsThirdPartyDocumentGateway;
     @Mock private IdentityVerificationService mockIdentityVerificationService;
 
     private DrivingPermitHandler drivingPermitHandler;
@@ -111,7 +113,8 @@ class DrivingPermitHandlerTest {
                 Mockito.mock(APIGatewayProxyRequestEvent.class);
 
         when(mockRequestEvent.getBody()).thenReturn(testRequestBody);
-        Map<String, String> requestHeaders = Map.of("session_id", sessionId.toString());
+        Map<String, String> requestHeaders =
+                Map.of("session_id", sessionId.toString(), HEADER_DOCUMENT_CHECKING_ROUTE, "dcs");
         when(mockRequestEvent.getHeaders()).thenReturn(requestHeaders);
 
         final var sessionItem = new SessionItem();
@@ -130,7 +133,7 @@ class DrivingPermitHandlerTest {
                 .sendAuditEvent(eq(AuditEventType.RESPONSE_RECEIVED), any(AuditEventContext.class));
 
         // Choose API
-        when(mockConfigurationService.getUseLegacy()).thenReturn(true);
+        when(mockConfigurationService.getDvaDirectEnabled()).thenReturn(false);
         when(mockThirdPartyAPIServiceFactory.getDcsThirdPartyAPIService())
                 .thenReturn(mockDcsThirdPartyDocumentGateway);
 
@@ -174,7 +177,12 @@ class DrivingPermitHandlerTest {
                 Mockito.mock(APIGatewayProxyRequestEvent.class);
 
         when(mockRequestEvent.getBody()).thenReturn(testRequestBody);
-        Map<String, String> requestHeaders = Map.of("session_id", UUID.randomUUID().toString());
+        Map<String, String> requestHeaders =
+                Map.of(
+                        "session_id",
+                        UUID.randomUUID().toString(),
+                        HEADER_DOCUMENT_CHECKING_ROUTE,
+                        "dcs");
         when(mockRequestEvent.getHeaders()).thenReturn(requestHeaders);
 
         final var sessionItem = new SessionItem();
@@ -192,7 +200,7 @@ class DrivingPermitHandlerTest {
                 .when(mockAuditService)
                 .sendAuditEvent(eq(AuditEventType.RESPONSE_RECEIVED), any(AuditEventContext.class));
 
-        when(mockConfigurationService.getUseLegacy()).thenReturn(true);
+        when(mockConfigurationService.getDvaDirectEnabled()).thenReturn(false);
         when(mockThirdPartyAPIServiceFactory.getDcsThirdPartyAPIService())
                 .thenReturn(mockDcsThirdPartyDocumentGateway);
 
@@ -242,7 +250,12 @@ class DrivingPermitHandlerTest {
                 Mockito.mock(APIGatewayProxyRequestEvent.class);
 
         when(mockRequestEvent.getBody()).thenReturn(testRequestBody);
-        Map<String, String> requestHeaders = Map.of("session_id", UUID.randomUUID().toString());
+        Map<String, String> requestHeaders =
+                Map.of(
+                        "session_id",
+                        UUID.randomUUID().toString(),
+                        HEADER_DOCUMENT_CHECKING_ROUTE,
+                        "dcs");
         when(mockRequestEvent.getHeaders()).thenReturn(requestHeaders);
 
         final var sessionItem = new SessionItem();
@@ -260,7 +273,7 @@ class DrivingPermitHandlerTest {
                 .when(mockAuditService)
                 .sendAuditEvent(eq(AuditEventType.RESPONSE_RECEIVED), any(AuditEventContext.class));
 
-        when(mockConfigurationService.getUseLegacy()).thenReturn(true);
+        when(mockConfigurationService.getDvaDirectEnabled()).thenReturn(false);
         when(mockThirdPartyAPIServiceFactory.getDcsThirdPartyAPIService())
                 .thenReturn(mockDcsThirdPartyDocumentGateway);
 
@@ -302,7 +315,12 @@ class DrivingPermitHandlerTest {
                 Mockito.mock(APIGatewayProxyRequestEvent.class);
 
         when(mockRequestEvent.getBody()).thenReturn(testRequestBody);
-        Map<String, String> requestHeaders = Map.of("session_id", UUID.randomUUID().toString());
+        Map<String, String> requestHeaders =
+                Map.of(
+                        "session_id",
+                        UUID.randomUUID().toString(),
+                        HEADER_DOCUMENT_CHECKING_ROUTE,
+                        "dcs");
         when(mockRequestEvent.getHeaders()).thenReturn(requestHeaders);
 
         final var sessionItem = new SessionItem();
@@ -342,7 +360,12 @@ class DrivingPermitHandlerTest {
                 Mockito.mock(APIGatewayProxyRequestEvent.class);
 
         when(mockRequestEvent.getBody()).thenReturn(testRequestBody);
-        Map<String, String> requestHeaders = Map.of("session_id", UUID.randomUUID().toString());
+        Map<String, String> requestHeaders =
+                Map.of(
+                        "session_id",
+                        UUID.randomUUID().toString(),
+                        HEADER_DOCUMENT_CHECKING_ROUTE,
+                        "dcs");
         when(mockRequestEvent.getHeaders()).thenReturn(requestHeaders);
 
         final var sessionItem = new SessionItem();
@@ -353,7 +376,7 @@ class DrivingPermitHandlerTest {
                 .thenReturn(drivingPermitForm);
 
         // Choose API
-        when(mockConfigurationService.getUseLegacy()).thenReturn(true);
+        when(mockConfigurationService.getDvaDirectEnabled()).thenReturn(false);
         when(mockThirdPartyAPIServiceFactory.getDcsThirdPartyAPIService())
                 .thenReturn(mockDcsThirdPartyDocumentGateway);
 

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ConfigurationServiceTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ConfigurationServiceTest.java
@@ -53,8 +53,8 @@ class ConfigurationServiceTest {
         when(mockParamProvider.get(
                         String.format(SPECIFIC_KEY_FORMAT, env, "DocumentCheckResultTableName")))
                 .thenReturn("FraudTableName");
-        when(mockParamProvider.get(String.format(SPECIFIC_KEY_FORMAT, env, "useLegacy")))
-                .thenReturn("useLegacy");
+        when(mockParamProvider.get(String.format(SPECIFIC_KEY_FORMAT, env, "dvaDirectEnabled")))
+                .thenReturn("dvaDirectEnabled");
         when(mockParamProvider.get(
                         String.format(
                                 SPECIFIC_KEY_FORMAT,

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/IdentityVerificationServiceTest.java
@@ -129,14 +129,14 @@ class IdentityVerificationServiceTest {
     }
 
     //    @Test
-    //    void verifyUseLegacyParameterRoutesUsersToDvaWhenFalse()
+    //    void verifyDvaDirectEnabledParameterRoutesUsersToDvaWhenTrue()
     //            throws IOException, InterruptedException, CertificateException, ParseException,
     //                    JOSEException, OAuthHttpResponseExceptionWithErrorBody {
     //        try (MockedStatic<LogManager> mockedLogManager = mockStatic(LogManager.class)) {
     //            Logger mockedStaticLogger = mock(Logger.class);
     //            mockedLogManager.when(LogManager::getLogger).thenReturn(mockedStaticLogger);
     //
-    //            when(configurationService.getUseLegacy()).thenReturn(false);
+    //            when(configurationService.getDvaDirectEnabled()).thenReturn(true);
     //            this.identityVerificationService =
     //                    new IdentityVerificationService(
     //                            mockFormDataValidator, mockContraindicationMapper,

--- a/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/IssueCredentialHandler.java
+++ b/lambdas/issuecredential/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/IssueCredentialHandler.java
@@ -125,7 +125,7 @@ public class IssueCredentialHandler
                             sessionItem.getSessionId());
 
             if (documentCheckResult == null) {
-                LOGGER.error("User has arrived in issue credential withou completing check");
+                LOGGER.error("User has arrived in issue credential without completing check");
                 return ApiGatewayResponseGenerator.proxyJsonResponse(
                         HttpStatusCode.INTERNAL_SERVER_ERROR,
                         OauthErrorResponse.ACCESS_DENIED_ERROR);


### PR DESCRIPTION
## Proposed changes

### What changed

- Added support for document checking route.
- Refactored existing route for clarification.

### Why did it change

- Change originally existed in now-redundant PR.

### Issue tracking

- [LIME-507](https://govukverify.atlassian.net/browse/LIME-507)

<img width="511" alt="image" src="https://github.com/alphagov/di-ipv-cri-dl-api/assets/107932230/142ade4f-256e-43d9-91ca-a0b28fddc9e2">


[LIME-507]: https://govukverify.atlassian.net/browse/LIME-507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="511" alt="image" src="https://github.com/alphagov/di-ipv-cri-dl-api/assets/107932230/f39e2764-65ab-4eb9-bab8-028f2c927b73">
