### PR TITLE
LIME-685 - Creating call to DVA direct api

### DIFF
--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/domain/dva/request/DvaPayload.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/domain/dva/request/DvaPayload.java
@@ -23,14 +23,11 @@ public class DvaPayload {
     private static final String TIMESTAMP_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
     private static final String TIME_ZONE = "UTC";
-
-    @JsonProperty private UUID correlationId;
     @JsonProperty private UUID requestId;
+    @JsonProperty private String issuerId;
     @JsonProperty private String timestamp;
-    @JsonProperty private String licenceNumber;
-    @JsonProperty private String driverNumber;
+    @JsonProperty private String driverLicenceNumber;
     @JsonProperty private String postcode;
-    @JsonProperty private String clientId = "di-ipv-passport-test-2021-12";
     @JsonProperty private String surname;
     @JsonProperty private String issueNumber;
 
@@ -53,31 +50,24 @@ public class DvaPayload {
 
     @JsonCreator
     public DvaPayload(
-            @JsonProperty(value = "surname", required = true) String surname,
-            @JsonProperty(value = "forenames", required = true) List<String> forenames,
+            @JsonProperty(value = "requestId", required = true) UUID requestId,
+            @JsonProperty(value = "familyName", required = true) String surname,
+            @JsonProperty(value = "givenNames", required = true) List<String> forenames,
             @JsonProperty(value = "dateOfBirth", required = true) LocalDate dateOfBirth,
-            @JsonProperty(value = "issueDate", required = false) LocalDate issueDate,
-            @JsonProperty(value = "dateOfIssue", required = false) LocalDate dateOfIssue,
-            @JsonProperty(value = "expiryDate", required = true) LocalDate expiryDate,
-            @JsonProperty(value = "postcode", required = true) String postcode) {
+            @JsonProperty(value = "validFrom", required = true) LocalDate dateOfIssue,
+            @JsonProperty(value = "validTo", required = true) LocalDate expiryDate,
+            @JsonProperty(value = "driverLicenceNumber", required = true)
+                    String driverLicenceNumber,
+            @JsonProperty(value = "address", required = true) String postcode) {
+        this.requestId = requestId;
         this.surname = surname;
         this.forenames = forenames;
         this.dateOfBirth = dateOfBirth;
-        this.issueDate = issueDate;
         this.dateOfIssue = dateOfIssue;
         this.expiryDate = expiryDate;
-        this.correlationId = UUID.randomUUID();
-        this.requestId = UUID.randomUUID();
+        this.driverLicenceNumber = driverLicenceNumber;
         this.timestamp = new SimpleDateFormat(TIMESTAMP_DATE_FORMAT).format(new Date());
         this.postcode = postcode;
-    }
-
-    public UUID getCorrelationId() {
-        return correlationId;
-    }
-
-    public void setCorrelationId(UUID correlationId) {
-        this.correlationId = correlationId;
     }
 
     public UUID getRequestId() {
@@ -94,14 +84,6 @@ public class DvaPayload {
 
     public void setTimestamp(String timestamp) {
         this.timestamp = timestamp;
-    }
-
-    public String getLicenceNumber() {
-        return licenceNumber;
-    }
-
-    public void setLicenceNumber(String licenceNumber) {
-        this.licenceNumber = licenceNumber;
     }
 
     public String getSurname() {
@@ -136,12 +118,12 @@ public class DvaPayload {
         this.expiryDate = expiryDate;
     }
 
-    public String getDriverNumber() {
-        return driverNumber;
+    public String getDriverLicenceNumber() {
+        return driverLicenceNumber;
     }
 
-    public void setDriverNumber(String driverNumber) {
-        this.driverNumber = driverNumber;
+    public void setDriverLicenceNumber(String driverLicenceNumber) {
+        this.driverLicenceNumber = driverLicenceNumber;
     }
 
     public String getPostcode() {
@@ -150,14 +132,6 @@ public class DvaPayload {
 
     public void setPostcode(String postcode) {
         this.postcode = postcode;
-    }
-
-    public String getClientId() {
-        return clientId;
-    }
-
-    public void setClientId(String clientId) {
-        this.clientId = clientId;
     }
 
     public LocalDate getIssueDate() {
@@ -184,43 +158,38 @@ public class DvaPayload {
         this.issueNumber = issueNumber;
     }
 
+    public String getIssuerId() {
+        return issuerId;
+    }
+
+    public void setIssuerId(String issuerId) {
+        this.issuerId = issuerId;
+    }
+
     @Override
     public String toString() {
-        return "DcsPayload{"
-                + "correlationId="
-                + correlationId
-                + ", requestId="
+        return "DvaPayload{"
+                + "requestId="
                 + requestId
                 + ", timestamp='"
                 + timestamp
                 + '\''
-                + ", licenceNumber='"
-                + licenceNumber
+                + ", driverLicenceNumber='"
+                + driverLicenceNumber
                 + '\''
-                + ", driverNumber='"
-                + driverNumber
-                + '\''
-                + ", postcode='"
+                + ", address='"
                 + postcode
                 + '\''
-                + ", clientId='"
-                + clientId
-                + '\''
-                + ", surname='"
+                + ", familyName='"
                 + surname
                 + '\''
-                + ", issueNumber='"
-                + issueNumber
-                + '\''
-                + ", forenames="
+                + ", givenNames="
                 + forenames
                 + ", dateOfBirth="
                 + dateOfBirth
-                + ", issueDate="
-                + issueDate
-                + ", dateOfIssue="
+                + ", validFrom="
                 + dateOfIssue
-                + ", expiryDate="
+                + ", validTo="
                 + expiryDate
                 + '}';
     }

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/domain/dva/response/DvaResponse.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/domain/dva/response/DvaResponse.java
@@ -8,58 +8,31 @@ import java.util.List;
 
 @ExcludeFromGeneratedCoverageReport
 public class DvaResponse {
-    private String correlationId;
-    private String requestId;
-    private boolean error;
-    private boolean valid;
     private List<String> errorMessage;
+    private String requestHash;
+    private boolean validDocument;
+    private String issuerID;
 
     public DvaResponse() {}
 
     @JsonCreator
     public DvaResponse(
-            @JsonProperty(value = "correlationId", required = true) String correlationId,
-            @JsonProperty(value = "requestId", required = true) String requestId,
-            @JsonProperty(value = "error") boolean error,
-            @JsonProperty(value = "valid") boolean valid,
+            @JsonProperty(value = "requestHash") String requestHash,
+            @JsonProperty(value = "validDocument") boolean validDocument,
+            @JsonProperty(value = "issuerID") String issuerID,
             @JsonProperty(value = "errorMessage") List<String> errorMessage) {
-        this.correlationId = correlationId;
-        this.requestId = requestId;
-        this.error = error;
-        this.valid = valid;
+        this.requestHash = requestHash;
+        this.validDocument = validDocument;
+        this.issuerID = issuerID;
         this.errorMessage = errorMessage;
     }
 
-    public String getCorrelationId() {
-        return correlationId;
+    public String getRequestHash() {
+        return requestHash;
     }
 
-    public void setCorrelationId(String correlationId) {
-        this.correlationId = correlationId;
-    }
-
-    public String getRequestId() {
-        return requestId;
-    }
-
-    public void setRequestId(String requestId) {
-        this.requestId = requestId;
-    }
-
-    public boolean isError() {
-        return error;
-    }
-
-    public void setError(boolean error) {
-        this.error = error;
-    }
-
-    public boolean isValid() {
-        return valid;
-    }
-
-    public void setValid(Boolean valid) {
-        this.valid = valid;
+    public boolean isValidDocument() {
+        return validDocument;
     }
 
     public List<String> getErrorMessage() {
@@ -70,19 +43,15 @@ public class DvaResponse {
         this.errorMessage = errorMessage;
     }
 
-    @Override
-    public String toString() {
-        return "DcsResponse{"
-                + "correlationId="
-                + correlationId
-                + ", requestId="
-                + requestId
-                + ", error="
-                + error
-                + ", valid="
-                + valid
-                + ", errorMessage="
-                + errorMessage
-                + '}';
+    public void setRequestHash(String requestHash) {
+        this.requestHash = requestHash;
+    }
+
+    public void setValidDocument(boolean validDocument) {
+        this.validDocument = validDocument;
+    }
+
+    public void setIssuerID(String issuerID) {
+        this.issuerID = issuerID;
     }
 }

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/error/ErrorResponse.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/error/ErrorResponse.java
@@ -31,7 +31,21 @@ public enum ErrorResponse {
     DCS_ERROR_HTTP_40X(1023, "DCS Responded with a HTTP Client Error status code"),
     DCS_ERROR_HTTP_50X(1024, "DCS Responded with a HTTP Server Error status code"),
     DCS_ERROR_HTTP_X(1025, "DCS Responded with an unhandled HTTP status code"),
-    TOO_MANY_RETRY_ATTEMPTS(1026, "Too many retry attempts made");
+    TOO_MANY_RETRY_ATTEMPTS(1026, "Too many retry attempts made"),
+
+    /**************************************DVA Specific Errors************************************/
+    FAILED_TO_PREPARE_DVA_PAYLOAD(1027, "Failed to prepare DCS payload"),
+    ERROR_CONTACTING_DVA(1028, "Error when contacting DCS for document check"),
+    FAILED_TO_UNWRAP_DVA_RESPONSE(1029, "Failed to unwrap Dcs response"),
+    DVA_RETURNED_AN_ERROR(1030, "DVA returned an error response"),
+    DVA_ERROR_HTTP_30X(1031, "DVA Responded with a HTTP Redirection status code"),
+    DVA_ERROR_HTTP_40X(1032, "DVA Responded with a HTTP Client Error status code"),
+
+    DVA_ERROR_HTTP_400(1033, "DVA Responded with an Invalid Request Error status code"),
+    DVA_ERROR_HTTP_401(1034, "DVA Responded with an Unauthorized Error status code"),
+    DVA_ERROR_HTTP_50X(1035, "DVA Responded with a HTTP Server Error status code"),
+    DVA_ERROR_HTTP_X(1036, "DVA Responded with an unhandled HTTP status code"),
+    DVA_RETURNED_AN_INCOMPLETE_RESPONSE(1037, "DVA returned a response with missing values");
 
     private final int code;
     private final String message;

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ThirdPartyAPIService.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ThirdPartyAPIService.java
@@ -6,6 +6,7 @@ import uk.gov.di.ipv.cri.drivingpermit.api.exception.OAuthHttpResponseExceptionW
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.DrivingPermitForm;
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.text.ParseException;
 
@@ -14,5 +15,6 @@ public interface ThirdPartyAPIService {
 
     DocumentCheckResult performDocumentCheck(DrivingPermitForm drivingPermitForm)
             throws InterruptedException, OAuthHttpResponseExceptionWithErrorBody,
-                    CertificateException, ParseException, JOSEException, IOException;
+                    CertificateException, ParseException, JOSEException, IOException,
+                    NoSuchAlgorithmException;
 }

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dcs/DcsCryptographyService.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dcs/DcsCryptographyService.java
@@ -80,8 +80,8 @@ public class DcsCryptographyService {
         ProtectedHeader protectedHeader =
                 new ProtectedHeader(
                         JWSAlgorithm.RS256.toString(),
-                        configurationService.getSigningCertThumbprints().getSha1Thumbprint(),
-                        configurationService.getSigningCertThumbprints().getSha256Thumbprint());
+                        configurationService.getSigningCertThumbprintsDcs().getSha1Thumbprint(),
+                        configurationService.getSigningCertThumbprintsDcs().getSha256Thumbprint());
 
         String jsonHeaders = objectMapper.writeValueAsString(protectedHeader);
 

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dcs/DcsThirdPartyDocumentGateway.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dcs/DcsThirdPartyDocumentGateway.java
@@ -40,7 +40,6 @@ import java.text.ParseException;
 import java.time.LocalDate;
 import java.util.Objects;
 
-import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.ISSUING_AUTHORITY_PREFIX;
 import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.THIRD_PARTY_DCS_RESPONSE_OK;
 import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.THIRD_PARTY_DCS_RESPONSE_TYPE_ERROR;
 import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.THIRD_PARTY_REQUEST_CREATED;
@@ -108,17 +107,9 @@ public class DcsThirdPartyDocumentGateway implements ThirdPartyAPIService {
 
         DcsPayload dcsPayload = objectMapper.convertValue(drivingPermitData, DcsPayload.class);
 
-        IssuingAuthority issuingAuthority;
-        try {
-            issuingAuthority = IssuingAuthority.valueOf(drivingPermitData.getLicenceIssuer());
-            LOGGER.info("Document Issuer {}", issuingAuthority);
-            eventProbe.counterMetric(
-                    ISSUING_AUTHORITY_PREFIX + issuingAuthority.toString().toLowerCase());
-        } catch (IllegalArgumentException e) {
-            throw new OAuthHttpResponseExceptionWithErrorBody(
-                    HttpStatusCode.INTERNAL_SERVER_ERROR,
-                    ErrorResponse.FAILED_TO_PARSE_DRIVING_PERMIT_FORM_DATA);
-        }
+        IssuingAuthority issuingAuthority =
+                IssuingAuthority.valueOf(drivingPermitData.getLicenceIssuer());
+
         LocalDate drivingPermitExpiryDate = drivingPermitData.getExpiryDate();
         String drivingPermitDocumentNumber = drivingPermitData.getDrivingLicenceNumber();
         LocalDate drivingPermitIssueDate = drivingPermitData.getIssueDate();
@@ -219,7 +210,7 @@ public class DcsThirdPartyDocumentGateway implements ThirdPartyAPIService {
             LOGGER.info("Third party response code {}", statusCode);
 
             try {
-                if (configurationService.isLogDcsResponse()) {
+                if (configurationService.isLogThirdPartyResponse()) {
                     LOGGER.info("DCS response " + responseBody);
                 }
                 DcsResponse unwrappedDcsResponse =

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaCryptographyService.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaCryptographyService.java
@@ -38,7 +38,6 @@ public class DvaCryptographyService {
     private final ObjectMapper objectMapper =
             new ObjectMapper().registerModule(new JavaTimeModule());
 
-    // TODO there rest of this class for dva and check nothing crosswird with dcs
     public DvaCryptographyService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
     }
@@ -81,8 +80,8 @@ public class DvaCryptographyService {
         ProtectedHeader protectedHeader =
                 new ProtectedHeader(
                         JWSAlgorithm.RS256.toString(),
-                        configurationService.getSigningCertThumbprints().getSha1Thumbprint(),
-                        configurationService.getSigningCertThumbprints().getSha256Thumbprint());
+                        configurationService.getSigningCertThumbprintsDva().getSha1Thumbprint(),
+                        configurationService.getSigningCertThumbprintsDva().getSha256Thumbprint());
 
         String jsonHeaders = objectMapper.writeValueAsString(protectedHeader);
 

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGateway.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGateway.java
@@ -1,31 +1,80 @@
 package uk.gov.di.ipv.cri.drivingpermit.api.service.dva;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.JWSObject;
+import com.nimbusds.jose.crypto.RSADecrypter;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.http.HttpStatusCode;
 import uk.gov.di.ipv.cri.common.library.util.EventProbe;
 import uk.gov.di.ipv.cri.drivingpermit.api.domain.DocumentCheckResult;
+import uk.gov.di.ipv.cri.drivingpermit.api.domain.dva.request.DvaPayload;
+import uk.gov.di.ipv.cri.drivingpermit.api.domain.dva.response.DvaResponse;
+import uk.gov.di.ipv.cri.drivingpermit.api.error.ErrorResponse;
+import uk.gov.di.ipv.cri.drivingpermit.api.exception.IpvCryptoException;
 import uk.gov.di.ipv.cri.drivingpermit.api.exception.OAuthHttpResponseExceptionWithErrorBody;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.ConfigurationService;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.HttpRetryer;
 import uk.gov.di.ipv.cri.drivingpermit.api.service.ThirdPartyAPIService;
+import uk.gov.di.ipv.cri.drivingpermit.library.domain.CheckDetails;
 import uk.gov.di.ipv.cri.drivingpermit.library.domain.DrivingPermitForm;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
+import java.security.spec.InvalidKeySpecException;
 import java.text.ParseException;
+import java.time.LocalDate;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.THIRD_PARTY_DVA_INVALID_REQUEST_ERROR;
+import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.THIRD_PARTY_DVA_RESPONSE_OK;
+import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.THIRD_PARTY_DVA_RESPONSE_TYPE_ERROR;
+import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.THIRD_PARTY_DVA_UNAUTHORIZED_ERROR;
+import static uk.gov.di.ipv.cri.drivingpermit.library.metrics.Definitions.THIRD_PARTY_REQUEST_CREATED;
 
 public class DvaThirdPartyDocumentGateway implements ThirdPartyAPIService {
 
     private static final String SERVICE_NAME = DvaThirdPartyDocumentGateway.class.getSimpleName();
-
+    private static final Logger LOGGER = LogManager.getLogger();
     private DvaCryptographyService dvaCryptographyService;
+    private final ObjectMapper objectMapper;
+    private final ConfigurationService configurationService;
+    private final HttpRetryer httpRetryer;
+    private final EventProbe eventProbe;
+    private static final String OPENID_CHECK_METHOD_IDENTIFIER = "data";
+    private static final String IDENTITY_CHECK_POLICY = "published";
 
     public DvaThirdPartyDocumentGateway(
             ObjectMapper objectMapper,
             DvaCryptographyService dvaCryptographyService,
             ConfigurationService configurationService,
             HttpRetryer httpRetryer,
-            EventProbe eventProbe) {}
+            EventProbe eventProbe) {
+        Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+        Objects.requireNonNull(dvaCryptographyService, "dvaCryptographyService must not be null");
+        Objects.requireNonNull(configurationService, "configurationService must not be null");
+        Objects.requireNonNull(httpRetryer, "httpRetryer must not be null");
+
+        this.objectMapper = objectMapper;
+        this.dvaCryptographyService = dvaCryptographyService;
+        this.configurationService = configurationService;
+        this.httpRetryer = httpRetryer;
+        this.eventProbe = eventProbe;
+    }
 
     @Override
     public String getServiceName() {
@@ -33,9 +82,218 @@ public class DvaThirdPartyDocumentGateway implements ThirdPartyAPIService {
     }
 
     @Override
-    public DocumentCheckResult performDocumentCheck(DrivingPermitForm drivingPermitForm)
+    public DocumentCheckResult performDocumentCheck(DrivingPermitForm drivingPermitData)
             throws InterruptedException, OAuthHttpResponseExceptionWithErrorBody,
-                    CertificateException, ParseException, JOSEException, IOException {
-        return null;
+                    CertificateException, ParseException, JOSEException, IOException,
+                    NoSuchAlgorithmException {
+        LOGGER.info("Mapping person to third party document check request");
+        DvaPayload dvaPayload = new DvaPayload();
+
+        String drivingPermitFamilyName = drivingPermitData.getSurname();
+        List<String> drivingPermitGivenNames = drivingPermitData.getForenames();
+        LocalDate drivingPermitDateOfBirth = drivingPermitData.getDateOfBirth();
+        LocalDate drivingPermitValidFrom = drivingPermitData.getIssueDate();
+        LocalDate drivingPermitValidTo = drivingPermitData.getExpiryDate();
+        String drivingPermitDriverLicenceNumber = drivingPermitData.getDrivingLicenceNumber();
+        String drivingPermitAddress = drivingPermitData.getPostcode();
+
+        String dvaEndpointUri = null;
+
+        // Note: dva direct request fields have different names/mappings to the
+        // drivingPermitForm
+        // the below is for mapping the form fields into the correct dva field names
+
+        dvaEndpointUri = configurationService.getDvaEndpointUri() + "/api/ukverify";
+        dvaPayload.setRequestId(UUID.randomUUID());
+        dvaPayload.setSurname(drivingPermitFamilyName);
+        dvaPayload.setForenames(drivingPermitGivenNames);
+        dvaPayload.setDateOfBirth(drivingPermitDateOfBirth);
+
+        dvaPayload.setExpiryDate(drivingPermitValidTo);
+        dvaPayload.setIssuerId("DVA");
+        dvaPayload.setDriverLicenceNumber(drivingPermitDriverLicenceNumber);
+        dvaPayload.setPostcode(drivingPermitAddress);
+
+        // Note: DateOfIssue is mapped to issueDate in the front end to simplify
+        // api handling of that field
+        // Here (for the DVA request) it needs to be mapped back to date of issue
+        dvaPayload.setDateOfIssue(drivingPermitValidFrom);
+
+        JWSObject preparedDvaPayload = preparePayload(dvaPayload);
+
+        String requestBody = preparedDvaPayload.serialize();
+
+        URI endpoint = URI.create(dvaEndpointUri);
+        HttpPost request = requestBuilder(endpoint, requestBody);
+
+        eventProbe.counterMetric(THIRD_PARTY_REQUEST_CREATED);
+
+        LOGGER.info("Submitting document check request to DVA...");
+
+        DocumentCheckResult documentCheckResult;
+        try (CloseableHttpResponse httpResponse =
+                httpRetryer.sendHTTPRequestRetryIfAllowed(request)) {
+            documentCheckResult =
+                    responseHandler(httpResponse, dvaPayload.getRequestId().toString());
+        }
+
+        if (documentCheckResult.isExecutedSuccessfully()) {
+            // Data capture for VC
+            CheckDetails checkDetails = new CheckDetails();
+            checkDetails.setCheckMethod(OPENID_CHECK_METHOD_IDENTIFIER);
+            checkDetails.setIdentityCheckPolicy(IDENTITY_CHECK_POLICY);
+
+            if (documentCheckResult.isValid()) {
+                // Map ActivityFrom to documentIssueDate (IssueDate / DateOfIssue)
+                checkDetails.setActivityFrom(drivingPermitValidFrom.toString());
+            }
+            documentCheckResult.setCheckDetails(checkDetails);
+        }
+
+        return documentCheckResult;
+    }
+
+    public JWSObject decrypt(JWEObject encrypted) {
+        try {
+            RSADecrypter rsaDecrypter =
+                    new RSADecrypter(configurationService.getDrivingPermitEncryptionKey());
+            encrypted.decrypt(rsaDecrypter);
+
+            return JWSObject.parse(encrypted.getPayload().toString());
+        } catch (ParseException | JOSEException exception) {
+            throw new IpvCryptoException(
+                    String.format("Cannot Decrypt DVA Payload: %s", exception.getMessage()));
+        }
+    }
+
+    private JWSObject preparePayload(DvaPayload dvaPayload)
+            throws OAuthHttpResponseExceptionWithErrorBody {
+        LOGGER.info("Preparing payload for DVA");
+        try {
+            return dvaCryptographyService.preparePayload(dvaPayload);
+        } catch (CertificateException
+                | NoSuchAlgorithmException
+                | InvalidKeySpecException
+                | JOSEException
+                | JsonProcessingException e) {
+            LOGGER.error(("Failed to prepare payload for DVA: " + e.getMessage()));
+            throw new OAuthHttpResponseExceptionWithErrorBody(
+                    HttpStatusCode.INTERNAL_SERVER_ERROR,
+                    ErrorResponse.FAILED_TO_PREPARE_DVA_PAYLOAD);
+        }
+    }
+
+    private void validateDvaResponse(DvaResponse dvaResponse)
+            throws OAuthHttpResponseExceptionWithErrorBody {
+        if (Objects.nonNull(dvaResponse.getRequestHash())) {
+            // RequestHash check
+        } else {
+            LOGGER.error("DVA returned an incomplete response");
+            throw new OAuthHttpResponseExceptionWithErrorBody(
+                    HttpStatusCode.BAD_GATEWAY, ErrorResponse.DVA_RETURNED_AN_INCOMPLETE_RESPONSE);
+        }
+    }
+
+    private DocumentCheckResult responseHandler(
+            CloseableHttpResponse httpResponse, String requestId)
+            throws IOException, ParseException, JOSEException, CertificateException,
+                    OAuthHttpResponseExceptionWithErrorBody {
+        int statusCode = httpResponse.getStatusLine().getStatusCode();
+
+        HttpEntity entity = httpResponse.getEntity();
+        String responseBody = EntityUtils.toString(entity);
+
+        LOGGER.info("Third party response code {}", statusCode);
+
+        if (statusCode == 200) {
+            try {
+                if (configurationService.isLogThirdPartyResponse()) {
+                    LOGGER.info("DVA response " + responseBody);
+                }
+                DvaResponse unwrappedDvaResponse =
+                        dvaCryptographyService.unwrapDvaResponse(responseBody);
+                validateDvaResponse(unwrappedDvaResponse);
+
+                LOGGER.info("Third party response successfully mapped");
+                eventProbe.counterMetric(THIRD_PARTY_DVA_RESPONSE_OK);
+
+                DocumentCheckResult documentCheckResult = new DocumentCheckResult();
+                documentCheckResult.setTransactionId(requestId);
+                documentCheckResult.setExecutedSuccessfully(true);
+                documentCheckResult.setValid(unwrappedDvaResponse.isValidDocument());
+
+                return documentCheckResult;
+            } catch (IpvCryptoException e) {
+                // Seen when a signing cert has expired and all message signatures fail verification
+                // We need to log this specific error message from the IpvCryptoException for
+                // context
+                LOGGER.error(e.getMessage(), e);
+                eventProbe.counterMetric(THIRD_PARTY_DVA_RESPONSE_TYPE_ERROR);
+                throw new OAuthHttpResponseExceptionWithErrorBody(
+                        HttpStatusCode.INTERNAL_SERVER_ERROR,
+                        ErrorResponse.FAILED_TO_UNWRAP_DVA_RESPONSE);
+            }
+        } else {
+
+            String responseText = responseBody == null ? "No Text Found" : responseBody;
+
+            LOGGER.error(
+                    "DVA replied with HTTP status code {}, response text: {}",
+                    statusCode,
+                    responseText);
+
+            eventProbe.counterMetric(THIRD_PARTY_DVA_RESPONSE_TYPE_ERROR);
+
+            if (statusCode >= 300 && statusCode <= 399) {
+                // Not Seen
+                throw new OAuthHttpResponseExceptionWithErrorBody(
+                        HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.DVA_ERROR_HTTP_30X);
+            } else if (statusCode >= 400 && statusCode <= 499) {
+                if (statusCode == 400) {
+                    LOGGER.error(
+                            "DVA replied with an InvalidRequestError. Please check the schema and request sent to DVA");
+                    eventProbe.counterMetric(THIRD_PARTY_DVA_INVALID_REQUEST_ERROR);
+
+                    throw new OAuthHttpResponseExceptionWithErrorBody(
+                            HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.DVA_ERROR_HTTP_400);
+                } else if (statusCode == 401) {
+                    LOGGER.error(
+                            "DVA replied with an UnauthorizedError. Please check the schema and request sent to DVA");
+                    eventProbe.counterMetric(THIRD_PARTY_DVA_UNAUTHORIZED_ERROR);
+
+                    throw new OAuthHttpResponseExceptionWithErrorBody(
+                            HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.DVA_ERROR_HTTP_401);
+                }
+                // Seen when a cert has expired
+                throw new OAuthHttpResponseExceptionWithErrorBody(
+                        HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.DVA_ERROR_HTTP_40X);
+            } else if (statusCode >= 500 && statusCode <= 599) {
+                // Error on DCS side
+                throw new OAuthHttpResponseExceptionWithErrorBody(
+                        HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.DVA_ERROR_HTTP_50X);
+            } else {
+                // Any other status codes
+                throw new OAuthHttpResponseExceptionWithErrorBody(
+                        HttpStatusCode.INTERNAL_SERVER_ERROR, ErrorResponse.DVA_ERROR_HTTP_X);
+            }
+        }
+    }
+
+    private HttpPost requestBuilder(URI endpointUri, String requestBody)
+            throws UnsupportedEncodingException {
+        String user = configurationService.getDvaUserName();
+        String pass = configurationService.getDvaPassword();
+        HttpPost request = new HttpPost(endpointUri);
+        request.addHeader("Content-Type", "application/jose");
+        // basic auth
+        request.addHeader("Authorization", getBasicAuthenticationHeader(user, pass));
+        request.setEntity(new StringEntity(requestBody));
+
+        return request;
+    }
+
+    private String getBasicAuthenticationHeader(String username, String password) {
+        String valueToEncode = username + ":" + password;
+        return "Basic " + Base64.getEncoder().encodeToString(valueToEncode.getBytes());
     }
 }

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ConfigurationServiceTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ConfigurationServiceTest.java
@@ -123,6 +123,9 @@ class ConfigurationServiceTest {
 
         when(mockParamProvider.get("/null/" + DVA_ENDPOINT)).thenReturn("DVA/dvaEndpoint");
 
+        when(mockParamProvider.get("/null/" + DVA_USERNAME)).thenReturn("DVA/Username");
+        when(mockParamProvider.get("/null/" + DVA_PASSWORD)).thenReturn("DVA/Password");
+
         when(mockParamProvider.get("/null/SessionTtl")).thenReturn("600");
 
         ConfigurationService configurationService =

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/IdentityVerificationServiceTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/IdentityVerificationServiceTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.ipv.cri.drivingpermit.library.domain.DrivingPermitForm;
 import uk.gov.di.ipv.cri.drivingpermit.library.testdata.DrivingPermitFormTestDataGenerator;
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.text.ParseException;
 import java.util.List;
@@ -55,7 +56,8 @@ class IdentityVerificationServiceTest {
     @Test
     void verifyIdentityShouldReturnResultWhenValidInputProvided()
             throws IOException, InterruptedException, CertificateException, ParseException,
-                    JOSEException, OAuthHttpResponseExceptionWithErrorBody {
+                    JOSEException, OAuthHttpResponseExceptionWithErrorBody,
+                    NoSuchAlgorithmException {
 
         this.identityVerificationService =
                 new IdentityVerificationService(
@@ -108,7 +110,7 @@ class IdentityVerificationServiceTest {
     @Test
     void verifyIdentityShouldReturnErrorWhenThirdPartyCallFails()
             throws IOException, InterruptedException, OAuthHttpResponseExceptionWithErrorBody,
-                    CertificateException, ParseException, JOSEException {
+                    CertificateException, ParseException, JOSEException, NoSuchAlgorithmException {
         DrivingPermitForm drivingPermitForm = DrivingPermitFormTestDataGenerator.generate();
         when(mockFormDataValidator.validate(drivingPermitForm))
                 .thenReturn(ValidationResult.createValidResult());

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/util/HttpResponseUtils.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/util/HttpResponseUtils.java
@@ -1,0 +1,194 @@
+package uk.gov.di.ipv.cri.drivingpermit.api.util;
+
+import org.apache.http.Header;
+import org.apache.http.HeaderIterator;
+import org.apache.http.HttpEntity;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.params.HttpParams;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Locale;
+
+public class HttpResponseUtils {
+    public static CloseableHttpResponse createHttpResponse(int statusCode) {
+        return new CloseableHttpResponse() {
+            @Override
+            public ProtocolVersion getProtocolVersion() {
+                return null;
+            }
+
+            @Override
+            public boolean containsHeader(String name) {
+                return false;
+            }
+
+            @Override
+            public Header[] getHeaders(String name) {
+                return new Header[0];
+            }
+
+            @Override
+            public Header getFirstHeader(String name) {
+                if ("Accept".equals(name)) {
+                    return new BasicHeader(name, "application/jose");
+                } else {
+                    return new BasicHeader(name, "application/jose");
+                }
+            }
+
+            @Override
+            public Header getLastHeader(String name) {
+                return null;
+            }
+
+            @Override
+            public Header[] getAllHeaders() {
+                return new Header[0];
+            }
+
+            @Override
+            public void addHeader(Header header) {}
+
+            @Override
+            public void addHeader(String name, String value) {}
+
+            @Override
+            public void setHeader(Header header) {}
+
+            @Override
+            public void setHeader(String name, String value) {}
+
+            @Override
+            public void setHeaders(Header[] headers) {}
+
+            @Override
+            public void removeHeader(Header header) {}
+
+            @Override
+            public void removeHeaders(String name) {}
+
+            @Override
+            public HeaderIterator headerIterator() {
+                return null;
+            }
+
+            @Override
+            public HeaderIterator headerIterator(String name) {
+                return null;
+            }
+
+            @Override
+            public HttpParams getParams() {
+                return null;
+            }
+
+            @Override
+            public void setParams(HttpParams params) {}
+
+            @Override
+            public StatusLine getStatusLine() {
+                return new StatusLine() {
+                    @Override
+                    public ProtocolVersion getProtocolVersion() {
+                        return null;
+                    }
+
+                    @Override
+                    public int getStatusCode() {
+                        return statusCode;
+                    }
+
+                    @Override
+                    public String getReasonPhrase() {
+                        return null;
+                    }
+                };
+            }
+
+            @Override
+            public void setStatusLine(StatusLine statusline) {}
+
+            @Override
+            public void setStatusLine(ProtocolVersion ver, int code) {}
+
+            @Override
+            public void setStatusLine(ProtocolVersion ver, int code, String reason) {}
+
+            @Override
+            public void setStatusCode(int code) throws IllegalStateException {}
+
+            @Override
+            public void setReasonPhrase(String reason) throws IllegalStateException {}
+
+            @Override
+            public HttpEntity getEntity() {
+                return new HttpEntity() {
+                    @Override
+                    public boolean isRepeatable() {
+                        return false;
+                    }
+
+                    @Override
+                    public boolean isChunked() {
+                        return false;
+                    }
+
+                    @Override
+                    public long getContentLength() {
+                        return 0;
+                    }
+
+                    @Override
+                    public Header getContentType() {
+                        return null;
+                    }
+
+                    @Override
+                    public Header getContentEncoding() {
+                        return null;
+                    }
+
+                    @Override
+                    public InputStream getContent()
+                            throws IOException, UnsupportedOperationException {
+                        String initialString = "";
+                        InputStream targetStream =
+                                new ByteArrayInputStream(initialString.getBytes());
+                        return targetStream;
+                    }
+
+                    @Override
+                    public void writeTo(OutputStream outStream) throws IOException {}
+
+                    @Override
+                    public boolean isStreaming() {
+                        return false;
+                    }
+
+                    @Override
+                    public void consumeContent() throws IOException {}
+                };
+            }
+
+            @Override
+            public void setEntity(HttpEntity entity) {}
+
+            @Override
+            public Locale getLocale() {
+                return null;
+            }
+
+            @Override
+            public void setLocale(Locale loc) {}
+
+            @Override
+            public void close() throws IOException {}
+        };
+    }
+}

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/util/MyJwsSigner.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/util/MyJwsSigner.java
@@ -1,0 +1,30 @@
+package uk.gov.di.ipv.cri.drivingpermit.api.util;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.jca.JCAContext;
+import com.nimbusds.jose.util.Base64URL;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class MyJwsSigner implements JWSSigner {
+    @Override
+    public Base64URL sign(JWSHeader header, byte[] signingInput) throws JOSEException {
+        return new Base64URL("base64Url");
+    }
+
+    @Override
+    public Set<JWSAlgorithm> supportedJWSAlgorithms() {
+        HashSet<JWSAlgorithm> hashSet = new HashSet<>();
+        hashSet.add(JWSAlgorithm.EdDSA);
+        return hashSet;
+    }
+
+    @Override
+    public JCAContext getJCAContext() {
+        return new JCAContext();
+    }
+}

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/config/ParameterStoreParameters.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/config/ParameterStoreParameters.java
@@ -57,6 +57,10 @@ public class ParameterStoreParameters {
 
     public static final String DVA_ENDPOINT = "DVA/dvaEndpoint";
 
+    public static final String DVA_USERNAME = "DVA/Username";
+
+    public static final String DVA_PASSWORD = "DVA/Password";
+
     @ExcludeFromGeneratedCoverageReport
     private ParameterStoreParameters() {
         throw new IllegalStateException("Instantiation is not valid for this class.");

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/metrics/Definitions.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/metrics/Definitions.java
@@ -51,6 +51,17 @@ public class Definitions {
     public static final String THIRD_PARTY_DCS_RESPONSE_TYPE_ERROR =
             "third_party_dcs_response_type_error";
 
+    // Third Party Response Type DVA
+    public static final String THIRD_PARTY_DVA_RESPONSE_OK = "third_party_dva_response_ok";
+    public static final String THIRD_PARTY_DVA_RESPONSE_TYPE_ERROR =
+            "third_party_dva_response_type_error";
+
+    public static final String THIRD_PARTY_DVA_INVALID_REQUEST_ERROR =
+            "third_party_dva_invalid_request_error";
+
+    public static final String THIRD_PARTY_DVA_UNAUTHORIZED_ERROR =
+            "third_party_dva_unauthorized_error";
+
     private Definitions() {
         throw new IllegalStateException("Instantiation is not valid for this class.");
     }

--- a/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/testdata/DrivingPermitFormTestDataGenerator.java
+++ b/lib/src/main/java/uk/gov/di/ipv/cri/drivingpermit/library/testdata/DrivingPermitFormTestDataGenerator.java
@@ -27,6 +27,12 @@ public class DrivingPermitFormTestDataGenerator {
         return generate(IssuingAuthority.DVLA);
     }
 
+    public static DrivingPermitForm generateDva() {
+        DrivingPermitForm drivingPermitForm = new DrivingPermitForm();
+
+        return generate(IssuingAuthority.DVA);
+    }
+
     public static DrivingPermitForm generate(IssuingAuthority issuingAuthority) {
         DrivingPermitForm drivingPermitForm = new DrivingPermitForm();
 


### PR DESCRIPTION
### What changed

Added new methods to perform document checks to DVA directly and map the response to existing document check result. As a part of this the dvaPayload and dvaResponse models had to be updated to match the expected field names found in the request/response. 

### Why did it change

To create request and response payloads that can be used in sending and receiving document check details to/from DVAs api and mapping them to the existing documentCheckResult model.

NOTE: The dvaResponse model is based off of what is expected to be found in the responses as defined in the documentation provided. I have incorporated a response that follows this into the DVA direct stub for now but some fields may need to be changed/added once we receive certificates and can connect to the real service.