### PR TITLE
LIME-787 Update selenium, webdrivermanager and cucumber

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -66,9 +66,9 @@ dependencies {
 	implementation "org.hamcrest:hamcrest:2.2"
 
 	implementation 'com.google.code.gson:gson:2.9.0'
-	implementation 'org.seleniumhq.selenium:selenium-java:4.2.1'
-	implementation 'io.github.bonigarcia:webdrivermanager:5.2.0'
-	implementation 'io.cucumber:cucumber-java:7.3.3'
+	implementation 'org.seleniumhq.selenium:selenium-java:4.11.0'
+	implementation 'io.github.bonigarcia:webdrivermanager:5.4.1'
+	implementation 'io.cucumber:cucumber-java:7.13.0'
 	implementation 'javax.annotation:javax.annotation-api:1.3.2'
 	implementation 'com.deque:axe-selenium:3.0'
 	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
@@ -76,7 +76,7 @@ dependencies {
 
 	testImplementation 'software.amazon.awssdk:s3:2.17.209'
 	testImplementation 'io.rest-assured:rest-assured:5.1.1'
-	testImplementation 'io.cucumber:cucumber-junit:7.3.3'
+	testImplementation 'io.cucumber:cucumber-junit:7.13.0'
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
 
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'


### PR DESCRIPTION
## Proposed changes

### What changed

Updated selenium, webdrivermanager and cucumber for acceptance tests

### Why did it change

Changes to the hosting of chrome for development can lead to being unable to run acceptance tests if a compatible version of chrome is not cached locally. 

An error similar to the following is logged `No such object: chromedriver/LATEST_RELEASE_116`

Known to happen in
- Pipeline test steps.
- Locally from a fresh clone

### Issue tracking

- [LIME-787](https://govukverify.atlassian.net/browse/LIME-787)

[LIME-787]: https://govukverify.atlassian.net/browse/LIME-787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ