### PR TITLE
LIME-493 Implement legacy feature toggle for each API

### DIFF
--- a/infrastructure/lambda/template.yaml
+++ b/infrastructure/lambda/template.yaml
@@ -148,6 +148,14 @@ Mappings:
       integration: "false"
       production: "false"
 
+  dvlaDirectEnabledMapping:
+    Environment:
+      dev: "true"
+      build: "true"
+      staging: "true"
+      integration: "false"
+      production: "false"
+
   DrivingPermitCriAudienceMapping:
     Environment:
       dev: "https://review-d.dev.account.gov.uk"
@@ -396,6 +404,7 @@ Resources:
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/contraindicationMappings"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/DocumentCheckResultTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/dvaDirectEnabled"
+                - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/dvlaDirectEnabled"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/verifiable-credential/issuer"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTableName"
                 - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CommonStackName}/SessionTtl"
@@ -653,6 +662,14 @@ Resources:
       Type: String
       Value: !FindInMap [ dvaDirectEnabledMapping, Environment, !Ref Environment ]
       Description: Feature toggle to switch between dcs/dva direct
+
+  dvlaDirectEnabledParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub "/${AWS::StackName}/dvlaDirectEnabled"
+      Type: String
+      Value: !FindInMap [ dvlaDirectEnabledMapping, Environment, !Ref Environment ]
+      Description: Feature toggle to switch between dcs/dvla direct
 
   LoggingKmsKey:
     Type: AWS::KMS::Key

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ConfigurationService.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ConfigurationService.java
@@ -51,6 +51,12 @@ public class ConfigurationService {
     private static final String KEY_FORMAT = "/%s/credentialIssuers/driving-permit/%s";
     private static final String PARAMETER_NAME_FORMAT = "/%s/%s";
 
+    // Feature toggles
+    private final boolean dvaDirectEnabled;
+    private final boolean dvlaDirectEnabled;
+    private final boolean isPerformanceStub;
+    private final boolean logThirdPartyResponse;
+
     private final String thirdPartyId;
     private final String documentCheckResultTableName;
     private final String contraindicationMappings;
@@ -58,7 +64,6 @@ public class ConfigurationService {
     private final String parameterPrefix;
     private final String commonParameterPrefix;
     private final String dvaEndpointUri;
-    private final boolean dvaDirectEnabled;
     private final Certificate dcsSigningCert;
     private final Certificate dcsEncryptionCert;
     private final Certificate drivingPermitTlsSelfCert;
@@ -82,8 +87,6 @@ public class ConfigurationService {
     private final Clock clock;
 
     private final long documentCheckItemTtl;
-    private final boolean isPerformanceStub;
-    private final boolean logThirdPartyResponse;
 
     public ConfigurationService(
             SecretsProvider secretsProvider, ParamProvider paramProvider, String env)
@@ -172,12 +175,13 @@ public class ConfigurationService {
         // *****************************Feature Toggles*******************************
         this.dvaDirectEnabled =
                 Boolean.parseBoolean(paramProvider.get(getParameterName("dvaDirectEnabled")));
+        this.dvlaDirectEnabled =
+                Boolean.parseBoolean(paramProvider.get(getParameterName("dlvaDirectEnabled")));
         this.isPerformanceStub =
                 Boolean.parseBoolean(paramProvider.get(getParameterName("isPerformanceStub")));
         this.logThirdPartyResponse =
                 Boolean.parseBoolean(paramProvider.get(getParameterName("logDcsResponse")));
         // *********************************Secrets***********************************
-
     }
 
     private PrivateKey getPrivateKey(ParamProvider paramProvider, String parameterName)
@@ -309,6 +313,10 @@ public class ConfigurationService {
 
     public boolean getDvaDirectEnabled() {
         return dvaDirectEnabled;
+    }
+
+    public boolean getDvlaDirectEnabled() {
+        return dvlaDirectEnabled;
     }
 
     public long getDocumentCheckItemExpirationEpoch() {

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ConfigurationService.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ConfigurationService.java
@@ -176,7 +176,7 @@ public class ConfigurationService {
         this.dvaDirectEnabled =
                 Boolean.parseBoolean(paramProvider.get(getParameterName("dvaDirectEnabled")));
         this.dvlaDirectEnabled =
-                Boolean.parseBoolean(paramProvider.get(getParameterName("dlvaDirectEnabled")));
+                Boolean.parseBoolean(paramProvider.get(getParameterName("dvlaDirectEnabled")));
         this.isPerformanceStub =
                 Boolean.parseBoolean(paramProvider.get(getParameterName("isPerformanceStub")));
         this.logThirdPartyResponse =

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ServiceFactory.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ServiceFactory.java
@@ -177,26 +177,8 @@ public class ServiceFactory {
         return contextSetup(keystoreTLS, trustStore);
     }
 
-    public CloseableHttpClient generateDvlaHttpClient(
-            ConfigurationService configurationService, boolean tlsOn)
-            throws NoSuchAlgorithmException, CertificateException, KeyStoreException, IOException,
-                    HttpException {
-        KeyStore keystoreTLS =
-                createKeyStore(
-                        null /*configurationService.getDvlaTlsSelfCert()*/,
-                        null /*configurationService.getDvlaDrivingPermitTlsKey()*/);
-
-        KeyStore trustStore =
-                createTrustStore(
-                        new Certificate[] {
-                            null /*configurationService.getDvlaTlsRootCert()*/,
-                            null /*configurationService.getDvlaTlsIntermediateCert()*/
-                        });
-
-        if (!tlsOn) {
-            return contextSetup(keystoreTLS, null);
-        }
-        return contextSetup(keystoreTLS, trustStore);
+    public CloseableHttpClient generateDvlaHttpClient() {
+        return HttpClients.custom().build();
     }
 
     private CloseableHttpClient contextSetup(KeyStore clientTls, KeyStore caBundle)

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ThirdPartyAPIServiceFactory.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ThirdPartyAPIServiceFactory.java
@@ -103,7 +103,7 @@ public class ThirdPartyAPIServiceFactory {
         DvlaEndpointFactory dvlaEndpointFactory = new DvlaEndpointFactory(configurationService);
 
         CloseableHttpClient httpClient =
-                serviceFactory.generateDvlaHttpClient(configurationService, tlsOn);
+                serviceFactory.generateDvlaHttpClient(/*configurationService, tlsOn*/ );
 
         HttpRetryer httpRetryer = new HttpRetryer(httpClient, eventProbe);
 

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ThirdPartyAPIServiceFactory.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/ThirdPartyAPIServiceFactory.java
@@ -37,7 +37,7 @@ public class ThirdPartyAPIServiceFactory {
         thirdPartyAPIServices[DCS] = createDcsThirdPartyDocumentGateway(serviceFactory, tlsOnDCS);
         thirdPartyAPIServices[DVA] = createDvaThirdPartyDocumentGateway(serviceFactory, tlsOnDva);
         thirdPartyAPIServices[DVLA] =
-                null; // createDvlaThirdPartyDocumentGateway(serviceFactory, tlsOnDvla);
+                createDvlaThirdPartyDocumentGateway(serviceFactory, tlsOnDvla);
     }
 
     private ThirdPartyAPIService createDcsThirdPartyDocumentGateway(

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/handler/DrivingPermitHandlerTest.java
@@ -430,7 +430,7 @@ class DrivingPermitHandlerTest {
 
     @ParameterizedTest
     @CsvSource({
-        // dvaEnabled, dvlaEnabled, documentCheckingRoute, licenseIssuer
+        // dvaEnabled, dvlaEnabled, documentCheckingRoute, licenseIssuer, expected api
 
         // API's enabled/ disabled, header has DCS
         "false, false, dcs, DVA, DcsThirdPartyDocumentGateway",


### PR DESCRIPTION
## Proposed changes

### What changed

DVLA
Added DLVA feature toggle.
Enabled creation of placeholder DvlaThirdPartyDocumentGateway

Added unit tests to ensure correct ThirdPartyAPIService is selected for each combination of the two feature flag and route.

Reverted api specific changes to to the DrivingPermitHandlerTest.

### Why did it change

DVLA
Feature toggled added follow existing pattern for DVA.
DvlaThirdPartyDocumentGateway creation needed for the unit test.

Unit test shouldSelectCorrectThirdPartyAPIServiceForEachIssuerAndFeatureToggle added to confirm which api the handler will select based on the values given to the private selectThirdPartyAPIService method.

Reverted changes to avoid duplicating the happy-path test of the handler for each api and then adding the same assertions to each.

### Issue tracking

- [LIME-493](https://govukverify.atlassian.net/browse/LIME-493)


[LIME-493]: https://govukverify.atlassian.net/browse/LIME-493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ