### PR TITLE
LIME-506 - Removing requestId from reguest hash in lower envs

### DIFF
--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGateway.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGateway.java
@@ -169,7 +169,10 @@ public class DvaThirdPartyDocumentGateway implements ThirdPartyAPIService {
             throws OAuthHttpResponseExceptionWithErrorBody, NoSuchAlgorithmException {
         if (Objects.nonNull(dvaResponse.getRequestHash())) {
             LOGGER.error("Validating DVA Direct response hash");
-            if (!requestHashValidator.valid(dvaPayload, dvaResponse.getRequestHash())) {
+            if (!requestHashValidator.valid(
+                    dvaPayload,
+                    dvaResponse.getRequestHash(),
+                    configurationService.isDvaPerformanceStub())) {
                 throw new OAuthHttpResponseExceptionWithErrorBody(
                         HttpStatusCode.BAD_REQUEST, ErrorResponse.DVA_D_HASH_VALIDATION_ERROR);
             } else {

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGatewayTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGatewayTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.ipv.cri.drivingpermit.api.util.HttpResponseUtils.createHttpResponse;
@@ -100,7 +101,8 @@ class DvaThirdPartyDocumentGatewayTest {
         jwsObject.sign(new MyJwsSigner());
         when(this.dvaCryptographyService.preparePayload(any(DvaPayload.class)))
                 .thenReturn(jwsObject);
-        when(this.requestHashValidator.valid(any(DvaPayload.class), anyString())).thenReturn(true);
+        when(this.requestHashValidator.valid(any(DvaPayload.class), anyString(), anyBoolean()))
+                .thenReturn(true);
 
         DocumentCheckResult actualDocumentCheckResult =
                 dvaThirdPartyDocumentGateway.performDocumentCheck(drivingPermitForm);
@@ -293,7 +295,8 @@ class DvaThirdPartyDocumentGatewayTest {
         jwsObject.sign(new MyJwsSigner());
         when(this.dvaCryptographyService.preparePayload(any(DvaPayload.class)))
                 .thenReturn(jwsObject);
-        when(this.requestHashValidator.valid(any(DvaPayload.class), anyString())).thenReturn(true);
+        when(this.requestHashValidator.valid(any(DvaPayload.class), anyString(), anyBoolean()))
+                .thenReturn(true);
 
         CloseableHttpResponse httpResponse = createHttpResponse(200);
 

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/HashFactoryTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/HashFactoryTest.java
@@ -29,8 +29,8 @@ public class HashFactoryTest {
         DvaResponse dvaResponse = createSuccessDvaResponse();
         hashFactory = new RequestHashValidator.HashFactory();
 
-        assertDoesNotThrow(() -> hashFactory.getHash(createSuccessDvaPayload()));
-        assertEquals(hashFactory.getHash(dvaPayload), dvaResponse.getRequestHash());
+        assertDoesNotThrow(() -> hashFactory.getHash(createSuccessDvaPayload(), false));
+        assertEquals(hashFactory.getHash(dvaPayload, false), dvaResponse.getRequestHash());
     }
 
     @Test
@@ -40,7 +40,7 @@ public class HashFactoryTest {
                 .thenThrow(new NoSuchAlgorithmException());
         assertThrows(
                 NoSuchAlgorithmException.class,
-                () -> hashFactory.getHash(createSuccessDvaPayload()));
+                () -> hashFactory.getHash(createSuccessDvaPayload(), false));
     }
 
     private DvaPayload createSuccessDvaPayload() {

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/RequestHashValidatorTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/RequestHashValidatorTest.java
@@ -21,9 +21,10 @@ class RequestHashValidatorTest {
         dvaPayload.setForenames(Arrays.asList("Fore"));
 
         DvaResponse dvaResponse = new DvaResponse();
-        dvaResponse.setRequestHash(hashFactory.getHash(dvaPayload) + "0");
+        dvaResponse.setRequestHash(hashFactory.getHash(dvaPayload, false) + "0");
 
-        boolean isValidHash = requestHashValidator.valid(dvaPayload, dvaResponse.getRequestHash());
+        boolean isValidHash =
+                requestHashValidator.valid(dvaPayload, dvaResponse.getRequestHash(), false);
 
         // Request Hash  = ad8[...]a5f
         // Response Hash = ad8[...]a5f0


### PR DESCRIPTION
### What changed

Updated requestHash validator to discard requestId from request hash generation to make compatible with static responses being returned from the DVA imposter stub

### Why did it change
request Id is unique per request, causing the generated request hash to be unique per request rather than per user. Due to the stub currently returning static responses for each test user of DVA, we need to be sure the request hashes included in the response from the stub match what is being sent to the stub/being generated in the Dl cri