### PR TITLE
LIME-515 -Updating acceptance tests to add direct document checking r…

### DIFF
--- a/acceptance-tests/build.gradle
+++ b/acceptance-tests/build.gradle
@@ -106,6 +106,9 @@ task cucumber() {
 
 	doLast {
 		javaexec {
+			systemProperties = [
+				'cucumber.tags': "${tags}"
+			]
 			main = "io.cucumber.core.cli.Main"
 			classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
 			args = [

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/UniversalStepDefs.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/step_definitions/UniversalStepDefs.java
@@ -3,7 +3,10 @@ package gov.di_ipv_drivingpermit.step_definitions;
 import gov.di_ipv_drivingpermit.pages.UniversalSteps;
 import io.cucumber.java.en.And;
 
+import java.util.Objects;
+
 import static gov.di_ipv_drivingpermit.utilities.BrowserUtils.changeLanguageTo;
+import static gov.di_ipv_drivingpermit.utilities.BrowserUtils.setFeatureSet;
 
 public class UniversalStepDefs extends UniversalSteps {
 
@@ -15,5 +18,17 @@ public class UniversalStepDefs extends UniversalSteps {
     @And("^I add a cookie to change the language to (.*)$")
     public void iAddACookieToChangeTheLanguageToWelsh(String language) {
         changeLanguageTo(language);
+    }
+
+    @And("^I set the document checking route$")
+    public void setDocumentCheckingRoute() {
+        if (getProperty("cucumber.tags").equals("@direct")) {
+            setFeatureSet("direct");
+        }
+    }
+
+    private static String getProperty(String propertyName) {
+        String property = System.getProperty(propertyName);
+        return Objects.requireNonNullElse(property, "");
     }
 }

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/BrowserUtils.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/BrowserUtils.java
@@ -429,6 +429,27 @@ public class BrowserUtils {
         Driver.get().get(newURL);
     }
 
+    public static void setFeatureSet(final String featureSet) {
+        LOGGER.info("Setting feature set : {}", featureSet);
+
+        String currentURL = Driver.get().getCurrentUrl();
+
+        String featureKeyValuePair = "featureSet=" + featureSet;
+        int li = currentURL.lastIndexOf('?');
+        String newURL;
+
+        if (li == -1) {
+            // First parameter
+            newURL = currentURL + "?" + featureKeyValuePair;
+        } else {
+            // Additional parameter
+            newURL = currentURL + "&" + featureKeyValuePair;
+        }
+
+        LOGGER.debug("newURL with feature set : {}", newURL);
+        Driver.get().get(newURL);
+    }
+
     public static HttpResponse<String> sendHttpRequest(HttpRequest request)
             throws IOException, InterruptedException {
         HttpClient client = HttpClient.newBuilder().build();

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DLProveYourIdentityFullJourneyRoute.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DLProveYourIdentityFullJourneyRoute.feature
@@ -38,6 +38,7 @@ Feature: Prove Your Identity Full Journey
     And I should be on `Who was your UK driving licence issued by? - Prove your identity - GOV.UK` page
     And I click on DVA radio button and Continue
     And I should be on DVA `Enter your details exactly as they appear on your UK driving licence - Prove your identity - GOV.UK` page
+    And I set the document checking route
     When User enters DVA data as a <DVADrivingLicenceSubject>
     And User clicks on continue
     And I enter BA2 5AA in the Postcode field and find address

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVADrivingLicence.feature
@@ -8,6 +8,7 @@ Feature: DVA Driving Licence Test
     And I should see DVA as an option
     And I click on DVA radio button and Continue
     And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I set the document checking route
     And I see a form requesting DVA LicenceNumber
 
   @DVADrivingLicence_test @build @staging @integration @smoke

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -8,6 +8,7 @@ Feature: Driving Licence Test
     And I should see DVLA as an option
     And I click on DVLA radio button and Continue
     And I check the page title is Enter your details exactly as they appear on your UK driving licence – Prove your identity – GOV.UK
+    And I set the document checking route
     And I see a form requesting DVLA LicenceNumber
 
   @DVLADrivingLicence_test @build @staging @integration @smoke

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicense.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DrivingLicense.feature
@@ -32,12 +32,14 @@ Feature: Driving License Test
   Scenario:User Selects DVLA and landed in DVLA page
     Given I click on DVLA radio button and Continue
     Then I should on the page DVLA Enter your details exactly as they appear on your UK driving licence - Prove your identity - GOV.UK
+    And I set the document checking route
     And The test is complete and I close the driver
 
   @DrivingLicenceTest @build @staging @integration
   Scenario:User Selects DVA and landed in DVA page
     Given I click on DVA radio button and Continue
     Then I should be on the page DVA Enter your details exactly as they appear on your UK driving licence - Prove your identity - GOV.UK
+    And I set the document checking route
     And The test is complete and I close the driver
 
   @DrivingLicenceTest


### PR DESCRIPTION
### What changed

Added functionality in step definitions to add the document checking route "direct" which can be used to toggle between direct connections and DCS

### Why did it change

So that we can test DCS and direct connections without creating a new suite of tests
