### PR TITLE
LIME-515 - Fixing request hashing to use dateOfIssue

### DIFF
--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGateway.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/DvaThirdPartyDocumentGateway.java
@@ -185,7 +185,7 @@ public class DvaThirdPartyDocumentGateway implements ThirdPartyAPIService {
     private void validateDvaResponse(DvaPayload dvaPayload, DvaResponse dvaResponse)
             throws OAuthErrorResponseException, NoSuchAlgorithmException {
         if (Objects.nonNull(dvaResponse.getRequestHash())) {
-            LOGGER.error("Validating DVA Direct response hash");
+            LOGGER.info("Validating DVA Direct response hash");
             if (!requestHashValidator.valid(
                     dvaPayload,
                     dvaResponse.getRequestHash(),
@@ -193,7 +193,7 @@ public class DvaThirdPartyDocumentGateway implements ThirdPartyAPIService {
                 throw new OAuthErrorResponseException(
                         HttpStatusCode.BAD_REQUEST, ErrorResponse.DVA_D_HASH_VALIDATION_ERROR);
             } else {
-                LOGGER.error("Successfully validated DVA Direct response hash");
+                LOGGER.info("Successfully validated DVA Direct response hash");
             }
         } else {
             LOGGER.error("DVA returned an incomplete response");

--- a/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/RequestHashValidator.java
+++ b/lambdas/drivingpermitcheck/src/main/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/RequestHashValidator.java
@@ -48,7 +48,7 @@ public class RequestHashValidator {
                                         .filter(Objects::nonNull)
                                         .reduce("", String::concat)
                                 + Objects.toString(request.getDateOfBirth(), "")
-                                + request.getIssueDate()
+                                + request.getDateOfIssue()
                                 + request.getExpiryDate()
                                 + request.getDriverLicenceNumber()
                                 + Objects.toString(request.getPostcode(), "");
@@ -61,7 +61,7 @@ public class RequestHashValidator {
                                         .filter(Objects::nonNull)
                                         .reduce("", String::concat)
                                 + Objects.toString(request.getDateOfBirth(), "")
-                                + request.getIssueDate()
+                                + request.getDateOfIssue()
                                 + request.getExpiryDate()
                                 + request.getDriverLicenceNumber()
                                 + Objects.toString(request.getPostcode(), "");

--- a/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/HashFactoryTest.java
+++ b/lambdas/drivingpermitcheck/src/test/java/uk/gov/di/ipv/cri/drivingpermit/api/service/dva/HashFactoryTest.java
@@ -52,7 +52,7 @@ public class HashFactoryTest {
         dvaPayload.setDriverLicenceNumber("12345678");
         dvaPayload.setDateOfBirth(LocalDate.of(1965, 7, 8));
         dvaPayload.setPostcode("BA2 5AA");
-        dvaPayload.setIssueDate(LocalDate.of(2018, 4, 19));
+        dvaPayload.setDateOfIssue(LocalDate.of(2018, 4, 19));
         dvaPayload.setExpiryDate(LocalDate.of(2042, 10, 1));
         dvaPayload.setIssuerId("DVA");
         return dvaPayload;


### PR DESCRIPTION
### What changed

Updated hashFactory to use dateOfIssue for request hashing rather than issueDate

### Why it changed

DVA uses dateOfIssue, DVLA use issueDate, the mismatch meant that there was a bug in the request hash being generated without a dateOfIssue
