### PR TITLE
LIME-765 Update Kenneth details and use Kenneth for happy path

### DIFF
--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DVAEnterYourDetailsExactlyPageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DVAEnterYourDetailsExactlyPageObject.java
@@ -142,7 +142,7 @@ public class DVAEnterYourDetailsExactlyPageObject extends DrivingLicencePageObje
     public void userEntersData(String issuer, String drivingLicenceSubjectScenario) {
         super.userEntersData(issuer, drivingLicenceSubjectScenario);
         TestInput drivingLicenceSubject =
-                TestDataCreator.getDVATestUserFromMap(issuer, drivingLicenceSubjectScenario);
+                TestDataCreator.getTestUserFromMap(issuer, drivingLicenceSubjectScenario);
         DVAEnterYourDetailsExactlyPageObject dvaEnterYourDetailsExactlyPage =
                 new DVAEnterYourDetailsExactlyPageObject();
         dvaEnterYourDetailsExactlyPage.dvaLicenceNumber.sendKeys(
@@ -180,7 +180,7 @@ public class DVAEnterYourDetailsExactlyPageObject extends DrivingLicencePageObje
 
     public void userReEntersDataAsDVADrivingLicenceSubject(String drivingLicenceSubjectScenario) {
         TestInput dvaDrivingLicenceSubject =
-                TestDataCreator.getDVATestUserFromMap("DVA", drivingLicenceSubjectScenario);
+                TestDataCreator.getTestUserFromMap("DVA", drivingLicenceSubjectScenario);
 
         dvaLicenceNumber.clear();
         LastName.clear();

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/pages/DrivingLicencePageObject.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import static gov.di_ipv_drivingpermit.pages.Headers.IPV_CORE_STUB;
 import static gov.di_ipv_drivingpermit.utilities.BrowserUtils.checkOkHttpResponseOnLink;
+import static java.lang.System.getenv;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -360,7 +361,7 @@ public class DrivingLicencePageObject extends UniversalSteps {
     public WebElement postcodeLabel;
 
     public DrivingLicencePageObject() {
-        this.configurationService = new ConfigurationService(System.getenv("ENVIRONMENT"));
+        this.configurationService = new ConfigurationService(getenv("ENVIRONMENT"));
         PageFactory.initElements(Driver.get(), this);
         TestDataCreator.createDefaultResponses();
     }
@@ -596,7 +597,7 @@ public class DrivingLicencePageObject extends UniversalSteps {
 
     public void userEntersData(String issuer, String drivingLicenceSubjectScenario) {
         TestInput drivingLicenceSubject =
-                TestDataCreator.getDVATestUserFromMap(issuer, drivingLicenceSubjectScenario);
+                TestDataCreator.getTestUserFromMap(issuer, drivingLicenceSubjectScenario);
         if (issuer.equals("DVLA")) {
             LicenceNumber.sendKeys(drivingLicenceSubject.getLicenceNumber());
             birthDay.sendKeys(drivingLicenceSubject.getBirthDay());
@@ -717,7 +718,7 @@ public class DrivingLicencePageObject extends UniversalSteps {
 
     public void userReEntersDataAsADrivingLicenceSubject(String drivingLicenceSubjectScenario) {
         TestInput drivingLicenceSubject =
-                TestDataCreator.getDVATestUserFromMap("DVLA", drivingLicenceSubjectScenario);
+                TestDataCreator.getTestUserFromMap("DVLA", drivingLicenceSubjectScenario);
 
         LicenceNumber.clear();
         LastName.clear();

--- a/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/TestDataCreator.java
+++ b/acceptance-tests/src/test/java/gov/di_ipv_drivingpermit/utilities/TestDataCreator.java
@@ -131,20 +131,20 @@ public class TestDataCreator {
 
         kennethDecerqueiraDvlaHappyPath =
                 new DrivingLicenceSubject(
-                        "DECER607085KE9LN",
+                        "DECER607085K99AE",
                         "DECERQUEIRA",
                         "KENNETH",
                         "",
                         "08",
                         "07",
                         "1965",
-                        "01",
-                        "10",
-                        "2042",
-                        "19",
+                        "27",
                         "04",
-                        "2018",
-                        "23",
+                        "2025",
+                        "22",
+                        "08",
+                        "2023",
+                        "16",
                         "BA2 5AA");
 
         peterHappyPath =
@@ -452,7 +452,6 @@ public class TestDataCreator {
         dvaTestUsers.put("IncorrectFirstName", billyBatsonIncorrectFirstName);
         dvaTestUsers.put("InvalidIssueDate", billyBatsonIncorrectInvalidIssueDate);
         dvaTestUsers.put("IncorrectIssueDate", billyBatsonIncorrectIssueDate);
-
         dvlaTestUsers.put("DrivingLicenceSubjectHappyPeter", peterHappyPath);
         dvlaTestUsers.put("DrivingLicenceSubjectHappyKenneth", kennethDecerqueiraDvlaHappyPath);
         dvlaTestUsers.put("KennethDOBJan", kennethDobJan);
@@ -520,7 +519,7 @@ public class TestDataCreator {
         dvlaTestUsers.put("IncorrectIssueDate", peterIncorrectIssueDate);
     }
 
-    public static TestInput getDVATestUserFromMap(String issuer, String scenario) {
+    public static TestInput getTestUserFromMap(String issuer, String scenario) {
         if (issuer.equals("DVLA")) {
             return dvlaTestUsers.get(scenario);
         } else {

--- a/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
+++ b/acceptance-tests/src/test/resources/features/UKDrivingLicence/DVLADrivingLicence.feature
@@ -17,12 +17,12 @@ Feature: Driving Licence Test
     When User clicks on continue
     Then I navigate to the Driving Licence verifiable issuer to check for a Valid response
     And JSON payload should contain validity score 2 and strength score 3
-    And JSON response should contain personal number PARKE610112PBFGH same as given Driving Licence
+    And JSON response should contain personal number DECER607085K99AE same as given Driving Licence
     And exp should not be present in the JSON payload
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject             |
-      |DrivingLicenceSubjectHappyPeter   |
+      |DrivingLicenceSubjectHappyKenneth   |
 
   @DVLADrivingLicence_test @build @staging @integration @dvlaDirect
   Scenario Outline: DVLA Driving Licence details page unhappy path with IncorrectDrivingLicenceNumber
@@ -150,7 +150,7 @@ Feature: Driving Licence Test
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject             |
-      |DrivingLicenceSubjectHappyPeter |
+      |DrivingLicenceSubjectHappyKenneth |
 
   @DVLADrivingLicence_test @build @staging @integration @smoke @dvlaDirect
   Scenario Outline: DVLA Driving Licence User failed second attempt
@@ -610,7 +610,7 @@ Feature: Driving Licence Test
     And The test is complete and I close the driver
     Examples:
       |DrivingLicenceSubject             |
-      |DrivingLicenceSubjectHappyPeter   |
+      |DrivingLicenceSubjectHappyKenneth   |
 
   @DVLADrivingLicence_test @build @staging @integration @dvlaDirect
   Scenario Outline:  DVLA Driving Licence number validation test - Correct licence number structure


### PR DESCRIPTION
## Proposed changes

### What changed

Align test user Kenneth with DVLA test data
Switch to using Kenneth for Happypath tests

~Removed assert on vc exp in several tests.~ Restored pending feature flag retirement 

### Why did it change

To allow testing DCS and DVLA via the same ac tests

~Assert always fails in dev.~

### Issue tracking

- [LIME-765](https://govukverify.atlassian.net/browse/LIME-765)



[LIME-765]: https://govukverify.atlassian.net/browse/LIME-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ